### PR TITLE
TCCL/UCX: fix error msg

### DIFF
--- a/tccl/src/team_lib/ucx/tccl_ucx_sendrecv.h
+++ b/tccl/src/team_lib/ucx/tccl_ucx_sendrecv.h
@@ -39,7 +39,7 @@ void tccl_ucx_recv_completion_cb(void* request, ucs_status_t status,
         if (UCS_PTR_IS_ERR(ucx_req)) {                                  \
             fprintf(stderr,"Error in %s: tag %d; dest %d; worker_id"    \
                     " %d; errmsg %s\n",                                 \
-                    tag, dest_group_rank,                               \
+                    __func__, tag, dest_group_rank,                     \
                     *((uint16_t *) &TEAM_UCX_WORKER(team)),             \
                     ucs_status_string(UCS_PTR_STATUS(ucx_req)));        \
             ucp_request_cancel(TEAM_UCX_WORKER(team), ucx_req);         \


### PR DESCRIPTION
CI build warnings:
```shell
In file included from allreduce/allreduce_knomial.c:4:0:
./tccl_ucx_sendrecv.h: In function ‘tccl_ucx_send_nb’:
./tccl_ucx_sendrecv.h:40:28: warning: format ‘%s’ expects argument of type ‘char *’, but argument 3 has type ‘uint32_t {aka unsigned int}’ [-Wformat=]
             fprintf(stderr,"Error in %s: tag %d; dest %d; worker_id"    \
                            ^
./tccl_ucx_sendrecv.h:40:28: note: in definition of macro ‘TEAM_UCX_CHECK_REQ_STATUS’
             fprintf(stderr,"Error in %s: tag %d; dest %d; worker_id"    \
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./tccl_ucx_sendrecv.h:118:5: note: in expansion of macro ‘TEAM_UCX_CHECK_SEND_REQ’
     TEAM_UCX_CHECK_SEND_REQ();
```