### PR TITLE
New API for tccl_lib_init

### DIFF
--- a/mccl/src/core/mccl.c
+++ b/mccl/src/core/mccl.c
@@ -119,6 +119,7 @@ int mccl_init_context(mccl_config_t *conf, mccl_context_h *context) {
     ctx->procs = (proc_data_t*)malloc(conf->world_size*sizeof(proc_data_t));
     mccl_get_bound_socket_id(&ctx->local_proc.socketid);
     memset(ctx->libs, 0, sizeof(ctx->libs));
+    *context = NULL;
     for (i=0; i<TCCL_LIB_LAST; i++) {
         ctx->libs[i].enabled = 1;
     }
@@ -138,7 +139,6 @@ int mccl_init_context(mccl_config_t *conf, mccl_context_h *context) {
        /* ctx->local_proc.node_hash, ctx->local_proc.socketid); */
     for (i=0; i<TCCL_LIB_LAST; i++) {
         if (MCCL_SUCCESS != mccl_tccl_init_lib(ctx, i)) {
-            *context = NULL;
             return MCCL_ERROR;
         }
     }

--- a/mccl/src/core/mccl.c
+++ b/mccl/src/core/mccl.c
@@ -55,26 +55,23 @@ static int mccl_tccl_init_lib(mccl_context_t *ctx, mccl_tccl_team_lib_t libtype)
         return MCCL_SUCCESS;
     }
 
-    tccl_team_lib_params_t lib_params = {
-        .tccl_model_type = TCCL_MODEL_TYPE_MPI,
-        .team_lib_name = tccl_libtype_to_char(libtype),
-        .ucp_context = NULL
-    };
-    if (TCCL_OK != tccl_team_lib_init(&lib_params, &ctx->libs[libtype].tccl_lib)) {
-        return MCCL_ERROR;
-    }
-
-    tccl_team_context_config_t team_ctx_config = {
-        .thread_support   = TCCL_THREAD_MODE_PRIVATE,
+    tccl_context_config_t team_ctx_config = {
+        .field_mask = TCCL_CONTEXT_CONFIG_FIELD_TEAM_LIB_NAME |
+                      TCCL_CONTEXT_CONFIG_FIELD_THREAD_MODE   |
+                      TCCL_CONTEXT_CONFIG_FIELD_OOB           |
+                      TCCL_CONTEXT_CONFIG_FIELD_COMPLETION_TYPE,
+        .team_lib_name    = tccl_libtype_to_char(libtype),
+        .thread_mode      = TCCL_LIB_THREAD_SINGLE,
         .completion_type  = TCCL_TEAM_COMPLETION_BLOCKING,
         .oob.allgather    = ctx->config.allgather,
         .oob.coll_context = ctx->config.oob_coll_ctx,
         .oob.rank         = ctx->config.world_rank,
         .oob.size         = ctx->config.world_size
     };
-
-    tccl_create_team_context(ctx->libs[libtype].tccl_lib, &team_ctx_config,
-                            &ctx->libs[libtype].tccl_ctx);
+    if (TCCL_OK != tccl_create_context(ctx->tccl_lib, team_ctx_config,
+                                       &ctx->libs[libtype].tccl_ctx)) {
+        return MCCL_ERROR;
+    }
     return MCCL_SUCCESS;
 }
 
@@ -125,8 +122,18 @@ int mccl_init_context(mccl_config_t *conf, mccl_context_h *context) {
     for (i=0; i<TCCL_LIB_LAST; i++) {
         ctx->libs[i].enabled = 1;
     }
-
     init_env_params(ctx);
+
+    tccl_lib_config_t lib_config = {
+        .field_mask = TCCL_LIB_CONFIG_FIELD_TEAM_USAGE,
+        .team_usage = TCCL_USAGE_SW_COLLECTIVES |
+        TCCL_USAGE_HW_COLLECTIVES,
+    };
+
+    if (TCCL_OK != tccl_lib_init(lib_config, &ctx->tccl_lib)) {
+        return MCCL_ERROR;
+    }
+
     /* printf("node: %s, node_hash %u, scoket id %d\n", hostname, */
        /* ctx->local_proc.node_hash, ctx->local_proc.socketid); */
     for (i=0; i<TCCL_LIB_LAST; i++) {
@@ -144,11 +151,12 @@ int mccl_finalize(mccl_context_h context) {
     mccl_context_t *ctx = (mccl_context_t *)context;
     int i;
     for (i=0; i<TCCL_LIB_LAST; i++) {
-        if (ctx->libs[i].tccl_lib) {
-            tccl_destroy_team_context(ctx->libs[i].tccl_ctx);
-            tccl_team_lib_finalize(ctx->libs[i].tccl_lib);
+        if (ctx->libs[i].enabled) {
+            assert(ctx->libs[i].tccl_ctx);
+            tccl_destroy_context(ctx->libs[i].tccl_ctx);
         }
     }
+    tccl_lib_finalize(ctx->tccl_lib);
     free(ctx->procs);
     free(ctx);
     return MCCL_SUCCESS;

--- a/mccl/src/core/mccl_core.h
+++ b/mccl/src/core/mccl_core.h
@@ -27,20 +27,20 @@ typedef enum {
 } mccl_tccl_team_lib_t;
 
 typedef struct mccl_team_lib_t {
-    tccl_team_lib_h     tccl_lib;
-    tccl_team_context_h tccl_ctx;
-    int                enabled;
+    tccl_context_h tccl_ctx;
+    int            enabled;
 } mccl_team_lib_t;
 
 typedef struct mccl_context_t {
-    mccl_config_t config;
-    proc_data_t local_proc; // local proc data
-    proc_data_t *procs; // data for all processes
-    int nnodes;
-    int min_ppn;
-    int max_ppn;
-    int max_sockets_per_node;
-    int max_ranks_per_socket;
+    mccl_config_t   config;
+    tccl_lib_h      tccl_lib;
+    proc_data_t     local_proc; // local proc data
+    proc_data_t    *procs; // data for all processes
+    int             nnodes;
+    int             min_ppn;
+    int             max_ppn;
+    int             max_sockets_per_node;
+    int             max_ranks_per_socket;
     mccl_team_lib_t libs[TCCL_LIB_LAST];
 } mccl_context_t;
 
@@ -59,12 +59,12 @@ typedef enum {
 
 typedef struct mccl_comm_t {
     mccl_comm_config_t config;
-    int *world_ranks; // map of local comm ranks to world ranks
-    sbgp_t sbgps[SBGP_LAST];
-    mccl_team_t *teams[MCCL_TEAM_LAST];
-    void *static_team_data[MCCL_TEAM_LAST];
-    int64_t seq_num;
-    int ctx_id; //TODO
+    int               *world_ranks; // map of local comm ranks to world ranks
+    sbgp_t             sbgps[SBGP_LAST];
+    mccl_team_t       *teams[MCCL_TEAM_LAST];
+    void              *static_team_data[MCCL_TEAM_LAST];
+    int64_t            seq_num;
+    int                ctx_id; //TODO
 } mccl_comm_t;
 
 int mccl_get_bound_socket_id(int *socketid);

--- a/mccl/test/mccl_test.c
+++ b/mccl/test/mccl_test.c
@@ -3,11 +3,9 @@
 *
 * See file LICENSE for terms.
 */
-#include <mpi.h>
-#include "api/mccl.h"
 #include <assert.h>
 #include <string.h>
-
+#include "mccl_test.h"
 int oob_allgather_ctx(void *sbuf, void *rbuf, size_t msglen, void *ctx) {
         MPI_Comm comm = (MPI_Comm)ctx;
         MPI_Allgather(sbuf, msglen, MPI_BYTE, rbuf, msglen, MPI_BYTE, comm);
@@ -55,7 +53,7 @@ int mccl_test_init(int argc, char **argv, uint64_t caps) {
         .oob_coll_ctx = (void*)MPI_COMM_WORLD,
     };
 
-    mccl_init_context(&config, &mccl_test_context);
+    MCCL_CHECK(mccl_init_context(&config, &mccl_test_context));
     mccl_comm_config_t comm_config = {
         .allgather = oob_allgather,
         .oob_coll_ctx = (void*)MPI_COMM_WORLD,
@@ -67,13 +65,13 @@ int mccl_test_init(int argc, char **argv, uint64_t caps) {
         .caps.tagged_colls = 0,
     };
 
-    mccl_comm_create(&comm_config, &mccl_comm_world);
+    MCCL_CHECK(mccl_comm_create(&comm_config, &mccl_comm_world));
     return MCCL_SUCCESS;
 }
 
 int mccl_test_fini(void) {
-    mccl_comm_free(mccl_comm_world);
-    mccl_finalize(mccl_test_context);
+    MCCL_CHECK(mccl_comm_free(mccl_comm_world));
+    MCCL_CHECK(mccl_finalize(mccl_test_context));
     MPI_Finalize();
     return MCCL_SUCCESS;
 }

--- a/mccl/test/mccl_test.c
+++ b/mccl/test/mccl_test.c
@@ -8,6 +8,12 @@
 #include <assert.h>
 #include <string.h>
 
+int oob_allgather_ctx(void *sbuf, void *rbuf, size_t msglen, void *ctx) {
+        MPI_Comm comm = (MPI_Comm)ctx;
+        MPI_Allgather(sbuf, msglen, MPI_BYTE, rbuf, msglen, MPI_BYTE, comm);
+        return 0;
+}
+
 int oob_allgather(void *sbuf, void *rbuf, size_t msglen,
                    int my_rank, int *ranks, int nranks,  void *oob_coll_ctx) {
     MPI_Comm comm = (MPI_Comm)oob_coll_ctx;
@@ -43,8 +49,10 @@ int mccl_test_init(int argc, char **argv, uint64_t caps) {
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 
     mccl_config_t config = {
-        .flags = 0,
-        .world_size = size,
+        .flags        = 0,
+        .world_size   = size,
+        .allgather    = oob_allgather_ctx,
+        .oob_coll_ctx = (void*)MPI_COMM_WORLD,
     };
 
     mccl_init_context(&config, &mccl_test_context);

--- a/mccl/test/mccl_test.h
+++ b/mccl/test/mccl_test.h
@@ -5,7 +5,18 @@
 */
 #ifndef MCCL_TEST_H_
 #define MCCL_TEST_H_
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <mpi.h>
 #include "api/mccl.h"
+
+#define STR(x) # x
+#define MCCL_CHECK(_call) if (MCCL_SUCCESS != (_call)) {\
+        fprintf(stderr, "fail: %s\n", STR(_call)); \
+        exit(-1);                                  \
+    }
 
 extern mccl_comm_h mccl_comm_world;
 int mccl_test_init(int argc, char **argv, uint64_t caps);

--- a/tccl/configure.ac
+++ b/tccl/configure.ac
@@ -106,5 +106,6 @@ AC_CONFIG_FILES([
                  src/team_lib/ucx/Makefile
                  src/team_lib/sharp/Makefile
                  src/team_lib/vmc/Makefile
+                 test/Makefile
                  ])
 AC_OUTPUT

--- a/tccl/configure.ac
+++ b/tccl/configure.ac
@@ -19,10 +19,11 @@ define([tccl_git_sha], esyscmd([sh -c "git rev-parse --short HEAD"]))
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 # current:rev:age
 define([libtccl_so_version], 1:0:0)
-
 AC_INIT([tccl], [tccl_ver_major.tccl_ver_minor])
-AC_USE_SYSTEM_EXTENSIONS
-AC_GNU_SOURCE
+: ${CPPFLAGS=""}
+: ${CFLAGS=""}
+: ${CXXFLAGS=""}
+
 AC_CONFIG_HEADERS([config.h])
 
 TCCL_TOP_BUILDDIR="`pwd`"
@@ -35,7 +36,6 @@ cd "$TCCL_TOP_BUILDDIR"
 
 AC_MSG_NOTICE([builddir: $TCCL_TOP_BUILDDIR])
 AC_MSG_NOTICE([srcdir: $TCCL_TOP_SRCDIR])
-
 AM_INIT_AUTOMAKE([1.10 foreign tar-ustar silent-rules subdir-objects])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_MAINTAINER_MODE

--- a/tccl/src/api/tccl.h
+++ b/tccl/src/api/tccl.h
@@ -16,6 +16,37 @@
  * This section describes TCCL API.
  * @}
  */
+/**
+ * @ingroup TCCL_TEAM_LIB
+ * @brief @todo
+ *
+ */
+typedef enum tccl_team_usage_type {
+    TCCL_USAGE_HW_COLLECTIVES    = TCCL_BIT(0),
+    TCCL_USAGE_SW_COLLECTIVES    = TCCL_BIT(1),
+    TCCL_USAGE_P2P_NETWORK       = TCCL_BIT(2),
+    TCCL_USAGE_HYBRID            = TCCL_BIT(3),
+    TCCL_USAGE_NO_COMMUNICATION  = TCCL_BIT(4)
+} tccl_team_usage_type_t;
+
+typedef enum tccl_lib_config_field_mask {
+        TCCL_LIB_CONFIG_FIELD_REPRODUCIBLE    = TCCL_BIT(0),
+        TCCL_LIB_CONFIG_FIELD_THREAD_MODE     = TCCL_BIT(1),
+        TCCL_LIB_CONFIG_FIELD_TEAM_USAGE      = TCCL_BIT(2),
+        TCCL_LIB_CONFIG_FIELD_CONTEXT_CONFIG  = TCCL_BIT(3),
+        TCCL_LIB_CONFIG_FIELD_TEAM_CONFIG     = TCCL_BIT(4),
+        TCCL_LIB_CONFIG_FIELD_COLL_TYPES      = TCCL_BIT(5)
+} tccl_lib_config_field_mask_t;
+
+typedef enum tccl_reproducibility {
+    TCCL_LIB_REPRODUCIBLE     = TCCL_BIT(0),
+    TCCL_LIB_NON_REPRODUCIBLE = TCCL_BIT(1),
+} tccl_reproducibility_t;
+
+typedef enum tccl_thread_mode {
+    TCCL_LIB_THREAD_MULTIPLE  = TCCL_BIT(0),
+    TCCL_LIB_THREAD_SINGLE    = TCCL_BIT(1),
+} tccl_thread_mode_t;
 
 /**
  * @ingroup TCCL_TEAM_CONTEXT
@@ -28,11 +59,6 @@ typedef enum {
     TCCL_TEAM_COMPLETION_SPLIT_PHASE = 2
 } tccl_team_completion_type_t;
 
-typedef enum {
-    TCCL_THREAD_MODE_PRIVATE = 0 ,
-    TCCL_THREAD_MODE_SHARED  = 1
-} tccl_threading_support_t;
-
 typedef struct tccl_oob_collectives {
     int (*allgather)(void *src_buf, void *recv_buff, size_t size,
                      void *coll_context);
@@ -41,8 +67,17 @@ typedef struct tccl_oob_collectives {
     int size;
 } tccl_oob_collectives_t;
 
+typedef enum tccl_context_config_field_mask {
+    TCCL_CONTEXT_CONFIG_FIELD_TEAM_LIB_NAME    = TCCL_BIT(0),
+    TCCL_CONTEXT_CONFIG_FIELD_THREAD_MODE      = TCCL_BIT(1),
+    TCCL_CONTEXT_CONFIG_FIELD_COMPLETION_TYPE  = TCCL_BIT(2),
+    TCCL_CONTEXT_CONFIG_FIELD_OOB              = TCCL_BIT(3),
+} tccl_context_config_field_mask_t;
+
 typedef struct tccl_team_context_config {
-    tccl_threading_support_t    thread_support;
+    uint64_t                    field_mask;
+    char*                       team_lib_name;
+    tccl_thread_mode_t          thread_mode;
     tccl_team_completion_type_t completion_type;
     tccl_oob_collectives_t      oob;
 } tccl_team_context_config_t;
@@ -104,11 +139,11 @@ typedef struct tccl_team_lib_attr {
 tccl_status_t tccl_team_lib_query(tccl_team_lib_h team_lib,
                                 tccl_team_lib_attr_t *attr);
 
-tccl_status_t tccl_create_team_context(tccl_team_lib_h lib,
-                                     tccl_team_context_config_h config,
-                                     tccl_team_context_h *team_ctx);
+tccl_status_t tccl_create_context(tccl_lib_h lib,
+                                  tccl_team_context_config_t config,
+                                  tccl_team_context_h *team_ctx);
 
-tccl_status_t tccl_destroy_team_context(tccl_team_context_h team_ctx);
+tccl_status_t tccl_destroy_context(tccl_team_context_h team_ctx);
 
 /**
  * @ingroup TCCL_TEAM
@@ -264,45 +299,14 @@ tccl_status_t tccl_collective_finalize(tccl_coll_req_h request);
 tccl_status_t tccl_context_progress(tccl_team_context_h context);
 
 /**
- * @ingroup TCCL_TEAM_LIB
- * @brief @todo
- *
- */
-typedef enum tccl_team_usage_type {
-    TCCL_USAGE_HW_COLLECTIVES    = TCCL_BIT(0),
-    TCCL_USAGE_SW_COLLECTIVES    = TCCL_BIT(1),
-    TCCL_USAGE_P2P_NETWORK       = TCCL_BIT(2),
-    TCCL_USAGE_HYBRID            = TCCL_BIT(3),
-    TCCL_USAGE_NO_COMMUNICATION  = TCCL_BIT(4)
-} tccl_team_usage_type_t;
-
-typedef enum tccl_lib_config_field_mask {
-        TCCL_LIB_CONFIG_FIELD_REPRODUCIBLE    = TCCL_BIT(0),
-        TCCL_LIB_CONFIG_FIELD_THREAD_MODE     = TCCL_BIT(1),
-        TCCL_LIB_CONFIG_FIELD_TEAM_USAGE      = TCCL_BIT(2),
-        TCCL_LIB_CONFIG_FIELD_CONTEXT_CONFIG  = TCCL_BIT(3),
-        TCCL_LIB_CONFIG_FIELD_TEAM_CONFIG     = TCCL_BIT(4),
-        TCCL_LIB_CONFIG_FIELD_COLL_TYPES      = TCCL_BIT(5)
-} tccl_lib_config_field_mask_t;
-
-typedef enum tccl_lib_reproducibility {
-    TCCL_LIB_REPRODUCIBLE     = TCCL_BIT(0),
-    TCCL_LIB_NON_REPRODUCIBLE = TCCL_BIT(1),
-} tccl_lib_reproducibility_t;
-
-typedef enum tccl_lib_thread_mode {
-    TCCL_LIB_THREAD_MULTIPLE  = TCCL_BIT(0),
-    TCCL_LIB_THREAD_SINGLE    = TCCL_BIT(1),
-} tccl_lib_thread_mode_t;
-/**
  * @ingroup TCCL_LIB
  * @brief TCCL team library initializatoin parameters
  *
  */
 typedef struct tccl_lib_config {
-        tccl_lib_config_field_mask_t field_mask;
-        tccl_lib_reproducibility_t   reproducible;
-        tccl_lib_thread_mode_t       thread_mode;
+        uint64_t                     field_mask;
+        tccl_reproducibility_t       reproducible;
+        tccl_thread_mode_t           thread_mode;
         tccl_team_usage_type_t       team_usage;
         tccl_collective_type_t       coll_types;
         tccl_team_context_config_t   context_config;

--- a/tccl/src/api/tccl.h
+++ b/tccl/src/api/tccl.h
@@ -18,45 +18,6 @@
  */
 
 /**
- * @ingroup TCCL_TEAM_LIB
- * @brief @todo
- *
- */
-enum tccl_model_type {
-    TCCL_MODEL_TYPE_MPI            = 0,
-    TCCL_MODE_TYPE_OPENSHMEM       = 1,
-    TCCL_MODEL_TYPE_CUDA_NCCL_PCCL = 2,
-    TCCL_MODEL_TYPE_THREADS        = 3
-};
-
-/**
- * @ingroup TCCL_TEAM_LIB
- * @brief TCCL team library initializatoin parameters
- *
- */
-typedef struct tccl_team_lib_params {
-    uint64_t                tccl_model_type;
-    char                   *team_lib_name;
-    void                   *ucp_context;
-} tccl_team_lib_params_t;
-
-/**
- * @ingroup UCP_TEAM_LIB
- * @brief Initialize team library
- *
- * @todo add description
- *
- * @param [in]  tccl_params (Library initialization parameters)
- * @param [out] team_lib   (TCCL team library handle)
- *
- * @return Error code
- */
-tccl_status_t tccl_team_lib_init(tccl_team_lib_params_t *tccl_params,
-                               tccl_team_lib_h *team_lib);
-
-tccl_status_t tccl_team_lib_finalize(tccl_team_lib_h lib);
-
-/**
  * @ingroup TCCL_TEAM_CONTEXT
  * @brief Completion symantics of collective operations
  *
@@ -204,19 +165,20 @@ tccl_status_t tccl_team_create_post(tccl_team_context_h team_ctx,
 tccl_status_t tccl_team_destroy(tccl_team_h team);
 
 typedef enum {
-    TCCL_BARRIER,
-    TCCL_ALLTOALL,
-    TCCL_ALLTOALLV,
-    TCCL_BCAST,
-    TCCL_GATHER,
-    TCCL_ALLGATHER,
-    TCCL_REDUCE,
-    TCCL_ALLREDUCE,
-    TCCL_SCATTER,
-    TCCL_FANIN,
-    TCCL_FANOUT,
-    TCCL_FLUSH_ALL,
-    TCCL_MULTICAST
+    TCCL_BARRIER     = TCCL_BIT(1),
+    TCCL_ALLTOALL    = TCCL_BIT(2),
+    TCCL_ALLTOALLV   = TCCL_BIT(3),
+    TCCL_BCAST       = TCCL_BIT(4),
+    TCCL_GATHER      = TCCL_BIT(5),
+    TCCL_ALLGATHER   = TCCL_BIT(6),
+    TCCL_REDUCE      = TCCL_BIT(7),
+    TCCL_ALLREDUCE   = TCCL_BIT(8),
+    TCCL_SCATTER     = TCCL_BIT(9),
+    TCCL_FANIN       = TCCL_BIT(10),
+    TCCL_FANOUT      = TCCL_BIT(11),
+    TCCL_FLUSH_ALL   = TCCL_BIT(12),
+    TCCL_MULTICAST   = TCCL_BIT(13),
+    TCCL_COLL_ALL    = TCCL_MASK(13)
 } tccl_collective_type_t;
 
 typedef enum {
@@ -300,6 +262,69 @@ tccl_status_t tccl_collective_test(tccl_coll_req_h request);
 tccl_status_t tccl_collective_finalize(tccl_coll_req_h request);
 
 tccl_status_t tccl_context_progress(tccl_team_context_h context);
+
+/**
+ * @ingroup TCCL_TEAM_LIB
+ * @brief @todo
+ *
+ */
+typedef enum tccl_team_usage_type {
+    TCCL_USAGE_HW_COLLECTIVES    = TCCL_BIT(0),
+    TCCL_USAGE_SW_COLLECTIVES    = TCCL_BIT(1),
+    TCCL_USAGE_P2P_NETWORK       = TCCL_BIT(2),
+    TCCL_USAGE_HYBRID            = TCCL_BIT(3),
+    TCCL_USAGE_NO_COMMUNICATION  = TCCL_BIT(4)
+} tccl_team_usage_type_t;
+
+typedef enum tccl_lib_config_field_mask {
+        TCCL_LIB_CONFIG_FIELD_REPRODUCIBLE    = TCCL_BIT(0),
+        TCCL_LIB_CONFIG_FIELD_THREAD_MODE     = TCCL_BIT(1),
+        TCCL_LIB_CONFIG_FIELD_TEAM_USAGE      = TCCL_BIT(2),
+        TCCL_LIB_CONFIG_FIELD_CONTEXT_CONFIG  = TCCL_BIT(3),
+        TCCL_LIB_CONFIG_FIELD_TEAM_CONFIG     = TCCL_BIT(4),
+        TCCL_LIB_CONFIG_FIELD_COLL_TYPES      = TCCL_BIT(5)
+} tccl_lib_config_field_mask_t;
+
+typedef enum tccl_lib_reproducibility {
+    TCCL_LIB_REPRODUCIBLE     = TCCL_BIT(0),
+    TCCL_LIB_NON_REPRODUCIBLE = TCCL_BIT(1),
+} tccl_lib_reproducibility_t;
+
+typedef enum tccl_lib_thread_mode {
+    TCCL_LIB_THREAD_MULTIPLE  = TCCL_BIT(0),
+    TCCL_LIB_THREAD_SINGLE    = TCCL_BIT(1),
+} tccl_lib_thread_mode_t;
+/**
+ * @ingroup TCCL_LIB
+ * @brief TCCL team library initializatoin parameters
+ *
+ */
+typedef struct tccl_lib_config {
+        tccl_lib_config_field_mask_t field_mask;
+        tccl_lib_reproducibility_t   reproducible;
+        tccl_lib_thread_mode_t       thread_mode;
+        tccl_team_usage_type_t       team_usage;
+        tccl_collective_type_t       coll_types;
+        tccl_team_context_config_t   context_config;
+        tccl_team_config_t           team_config;
+} tccl_lib_config_t;
+
+/**
+ * @ingroup UCP_TEAM_LIB
+ * @brief Initialize team library
+ *
+ * @todo add description
+ *
+ * @param [in]  tccl_params (Library initialization parameters)
+ * @param [out] team_lib   (TCCL team library handle)
+ *
+ * @return Error code
+ */
+tccl_status_t tccl_lib_init(tccl_lib_config_t lib_config,
+                            tccl_lib_h *lib);
+
+tccl_status_t tccl_lib_finalize(tccl_lib_h lib);
+
 
 static inline size_t tccl_dt_size(tccl_dt_t dt) {
     switch(dt) {

--- a/tccl/src/api/tccl.h
+++ b/tccl/src/api/tccl.h
@@ -30,12 +30,12 @@ typedef enum tccl_team_usage_type {
 } tccl_team_usage_type_t;
 
 typedef enum tccl_lib_config_field_mask {
-        TCCL_LIB_CONFIG_FIELD_REPRODUCIBLE    = TCCL_BIT(0),
-        TCCL_LIB_CONFIG_FIELD_THREAD_MODE     = TCCL_BIT(1),
-        TCCL_LIB_CONFIG_FIELD_TEAM_USAGE      = TCCL_BIT(2),
-        TCCL_LIB_CONFIG_FIELD_CONTEXT_CONFIG  = TCCL_BIT(3),
-        TCCL_LIB_CONFIG_FIELD_TEAM_CONFIG     = TCCL_BIT(4),
-        TCCL_LIB_CONFIG_FIELD_COLL_TYPES      = TCCL_BIT(5)
+    TCCL_LIB_CONFIG_FIELD_REPRODUCIBLE    = TCCL_BIT(0),
+    TCCL_LIB_CONFIG_FIELD_THREAD_MODE     = TCCL_BIT(1),
+    TCCL_LIB_CONFIG_FIELD_TEAM_USAGE      = TCCL_BIT(2),
+    TCCL_LIB_CONFIG_FIELD_CONTEXT_CONFIG  = TCCL_BIT(3),
+    TCCL_LIB_CONFIG_FIELD_TEAM_CONFIG     = TCCL_BIT(4),
+    TCCL_LIB_CONFIG_FIELD_COLL_TYPES      = TCCL_BIT(5)
 } tccl_lib_config_field_mask_t;
 
 typedef enum tccl_reproducibility {
@@ -200,19 +200,19 @@ tccl_status_t tccl_team_create_post(tccl_context_h team_ctx,
 tccl_status_t tccl_team_destroy(tccl_team_h team);
 
 typedef enum {
-    TCCL_BARRIER     = TCCL_BIT(1),
-    TCCL_ALLTOALL    = TCCL_BIT(2),
-    TCCL_ALLTOALLV   = TCCL_BIT(3),
-    TCCL_BCAST       = TCCL_BIT(4),
-    TCCL_GATHER      = TCCL_BIT(5),
-    TCCL_ALLGATHER   = TCCL_BIT(6),
-    TCCL_REDUCE      = TCCL_BIT(7),
-    TCCL_ALLREDUCE   = TCCL_BIT(8),
-    TCCL_SCATTER     = TCCL_BIT(9),
-    TCCL_FANIN       = TCCL_BIT(10),
-    TCCL_FANOUT      = TCCL_BIT(11),
-    TCCL_FLUSH_ALL   = TCCL_BIT(12),
-    TCCL_MULTICAST   = TCCL_BIT(13),
+    TCCL_BARRIER     = TCCL_BIT(0),
+    TCCL_ALLTOALL    = TCCL_BIT(1),
+    TCCL_ALLTOALLV   = TCCL_BIT(2),
+    TCCL_BCAST       = TCCL_BIT(3),
+    TCCL_GATHER      = TCCL_BIT(4),
+    TCCL_ALLGATHER   = TCCL_BIT(5),
+    TCCL_REDUCE      = TCCL_BIT(6),
+    TCCL_ALLREDUCE   = TCCL_BIT(7),
+    TCCL_SCATTER     = TCCL_BIT(8),
+    TCCL_FANIN       = TCCL_BIT(9),
+    TCCL_FANOUT      = TCCL_BIT(10),
+    TCCL_FLUSH_ALL   = TCCL_BIT(11),
+    TCCL_MULTICAST   = TCCL_BIT(12),
     TCCL_COLL_ALL    = TCCL_MASK(13)
 } tccl_collective_type_t;
 
@@ -276,9 +276,9 @@ typedef struct tccl_coll_op_args {
     tccl_collective_type_t  coll_type;
     tccl_coll_buffer_info_t buffer_info;
     tccl_reduce_info_t      reduce_info;
-    int                    root;
+    int                     root;
     tccl_coll_algorithm_t   alg;
-    uint16_t               tag;
+    uint16_t                tag;
 } tccl_coll_op_args_t;
 
 typedef struct tccl_coll_req {
@@ -304,13 +304,13 @@ tccl_status_t tccl_context_progress(tccl_context_h context);
  *
  */
 typedef struct tccl_lib_config {
-        uint64_t                     field_mask;
-        tccl_reproducibility_t       reproducible;
-        tccl_thread_mode_t           thread_mode;
-        tccl_team_usage_type_t       team_usage;
-        tccl_collective_type_t       coll_types;
-        tccl_context_config_t        context_config;
-        tccl_team_config_t           team_config;
+    uint64_t                     field_mask;
+    tccl_reproducibility_t       reproducible;
+    tccl_thread_mode_t           thread_mode;
+    tccl_team_usage_type_t       team_usage;
+    tccl_collective_type_t       coll_types;
+    tccl_context_config_t        context_config;
+    tccl_team_config_t           team_config;
 } tccl_lib_config_t;
 
 /**

--- a/tccl/src/api/tccl.h
+++ b/tccl/src/api/tccl.h
@@ -74,13 +74,13 @@ typedef enum tccl_context_config_field_mask {
     TCCL_CONTEXT_CONFIG_FIELD_OOB              = TCCL_BIT(3),
 } tccl_context_config_field_mask_t;
 
-typedef struct tccl_team_context_config {
+typedef struct tccl_context_config {
     uint64_t                    field_mask;
     char*                       team_lib_name;
     tccl_thread_mode_t          thread_mode;
     tccl_team_completion_type_t completion_type;
     tccl_oob_collectives_t      oob;
-} tccl_team_context_config_t;
+} tccl_context_config_t;
 
 
 typedef enum {
@@ -140,10 +140,10 @@ tccl_status_t tccl_team_lib_query(tccl_team_lib_h team_lib,
                                 tccl_team_lib_attr_t *attr);
 
 tccl_status_t tccl_create_context(tccl_lib_h lib,
-                                  tccl_team_context_config_t config,
-                                  tccl_team_context_h *team_ctx);
+                                  tccl_context_config_t config,
+                                  tccl_context_h *team_ctx);
 
-tccl_status_t tccl_destroy_context(tccl_team_context_h team_ctx);
+tccl_status_t tccl_destroy_context(tccl_context_h team_ctx);
 
 /**
  * @ingroup TCCL_TEAM
@@ -193,7 +193,7 @@ typedef struct tccl_team_config {
     tccl_ep_range_t range;
 } tccl_team_config_t;
 
-tccl_status_t tccl_team_create_post(tccl_team_context_h team_ctx,
+tccl_status_t tccl_team_create_post(tccl_context_h team_ctx,
                                   tccl_team_config_h config,
                                   tccl_oob_collectives_t oob, tccl_team_h *team);
 
@@ -296,7 +296,7 @@ tccl_status_t tccl_collective_test(tccl_coll_req_h request);
 
 tccl_status_t tccl_collective_finalize(tccl_coll_req_h request);
 
-tccl_status_t tccl_context_progress(tccl_team_context_h context);
+tccl_status_t tccl_context_progress(tccl_context_h context);
 
 /**
  * @ingroup TCCL_LIB
@@ -309,7 +309,7 @@ typedef struct tccl_lib_config {
         tccl_thread_mode_t           thread_mode;
         tccl_team_usage_type_t       team_usage;
         tccl_collective_type_t       coll_types;
-        tccl_team_context_config_t   context_config;
+        tccl_context_config_t        context_config;
         tccl_team_config_t           team_config;
 } tccl_lib_config_t;
 

--- a/tccl/src/api/tccl_def.h
+++ b/tccl/src/api/tccl_def.h
@@ -32,7 +32,7 @@ typedef struct tccl_team* tccl_team_h;
  *
  * @todo add description here
  */
-typedef struct tccl_team_context* tccl_team_context_h;
+typedef struct tccl_context* tccl_context_h;
 
 /**
  * @ingroup TCCL_TEAM_CONTEXT
@@ -40,7 +40,7 @@ typedef struct tccl_team_context* tccl_team_context_h;
  *
  * @todo add description here
  */
-typedef struct tccl_team_context_config* tccl_team_context_config_h;
+typedef struct tccl_context_config* tccl_context_config_h;
 
 /**
  * @ingroup TCCL_TEAM

--- a/tccl/src/api/tccl_def.h
+++ b/tccl/src/api/tccl_def.h
@@ -16,6 +16,7 @@
  * @todo add description here
  */
 typedef struct tccl_team_lib* tccl_team_lib_h;
+typedef struct tccl_lib* tccl_lib_h;
 
 /**
  * @ingroup TCCL_TEAM
@@ -58,4 +59,7 @@ typedef struct tccl_team_config* tccl_team_config_h;
 
 typedef struct tccl_coll_req* tccl_coll_req_h;
 
+#define TCCL_BIT(i)               (1ul << (i))
+#define TCCL_MASK(i)              (TCCL_BIT(i) - 1)
+#define TCCL_PP_QUOTE(x)                 # x
 #endif

--- a/tccl/src/api/tccl_status.h
+++ b/tccl/src/api/tccl_status.h
@@ -24,6 +24,7 @@ typedef enum {
     TCCL_ERR_MESSAGE_TRUNCATED      =  -9,
     TCCL_ERR_NO_PROGRESS            = -10,
     TCCL_ERR_BUFFER_TOO_SMALL       = -11,
+    TCCL_ERR_NO_ELEM                = -12,
     TCCL_ERR_UNSUPPORTED            = -22,
     TCCL_ERR_LAST                   = -100
 } tccl_status_t;

--- a/tccl/src/team_lib/sharp/tccl_team_lib_sharp.c
+++ b/tccl/src/team_lib/sharp/tccl_team_lib_sharp.c
@@ -83,8 +83,8 @@ int tccl_team_sharp_oob_bcast(void *context, void *buf, int size, int root)
 
 static tccl_status_t
 tccl_team_sharp_create_context(tccl_team_lib_h team_lib,
-                              tccl_team_context_config_h config,
-                              tccl_team_context_h *team_context)
+                              tccl_context_config_h config,
+                              tccl_context_h *team_context)
 {
     tccl_team_sharp_context_t *team_sharp_ctx = malloc(sizeof(*team_sharp_ctx));
     struct sharp_coll_init_spec init_spec = {0};
@@ -120,12 +120,12 @@ tccl_team_sharp_create_context(tccl_team_lib_h team_lib,
         free(team_sharp_ctx);
         return TCCL_ERR_NO_MESSAGE;
     }
-    *team_context = (tccl_team_context_h)team_sharp_ctx;
+    *team_context = (tccl_context_h)team_sharp_ctx;
     return TCCL_OK;
 }
 
 static tccl_status_t
-tccl_team_sharp_destroy_context(tccl_team_context_h team_context)
+tccl_team_sharp_destroy_context(tccl_context_h team_context)
 {
     tccl_team_sharp_context_t *team_sharp_ctx =
         (tccl_team_sharp_context_t *)team_context;
@@ -137,7 +137,7 @@ tccl_team_sharp_destroy_context(tccl_team_context_h team_context)
 }
 
 static tccl_status_t
-tccl_team_sharp_create_post(tccl_team_context_h team_context,
+tccl_team_sharp_create_post(tccl_context_h team_context,
                            tccl_team_config_h config,
                            tccl_oob_collectives_t oob,
                            tccl_team_h *team)

--- a/tccl/src/team_lib/sharp/tccl_team_lib_sharp.c
+++ b/tccl/src/team_lib/sharp/tccl_team_lib_sharp.c
@@ -203,7 +203,7 @@ static tccl_status_t tccl_team_sharp_destroy(tccl_team_h team)
 }
 
 tccl_team_lib_sharp_t tccl_team_lib_sharp = {
-    .super.name                 = "team_lib_sharp",
+    .super.name                 = "sharp",
     .super.priority             = 100,
     .super.config.reproducible  = TCCL_LIB_NON_REPRODUCIBLE,
     .super.config.thread_mode   = TCCL_LIB_THREAD_SINGLE | TCCL_LIB_THREAD_MULTIPLE,

--- a/tccl/src/team_lib/sharp/tccl_team_lib_sharp.c
+++ b/tccl/src/team_lib/sharp/tccl_team_lib_sharp.c
@@ -204,6 +204,11 @@ static tccl_status_t tccl_team_sharp_destroy(tccl_team_h team)
 
 tccl_team_lib_sharp_t tccl_team_lib_sharp = {
     .super.name                 = "team_lib_sharp",
+    .super.priority             = 100,
+    .super.config.reproducible  = TCCL_LIB_NON_REPRODUCIBLE,
+    .super.config.thread_mode   = TCCL_LIB_THREAD_SINGLE | TCCL_LIB_THREAD_MULTIPLE,
+    .super.config.team_usage    = TCCL_USAGE_HW_COLLECTIVES,
+    .super.config.coll_types    = TCCL_BARRIER | TCCL_ALLREDUCE,
     .super.ctx_create_mode      = TCCL_TEAM_LIB_CONTEXT_CREATE_MODE_GLOBAL,
     .super.create_team_context  = tccl_team_sharp_create_context,
     .super.destroy_team_context = tccl_team_sharp_destroy_context,

--- a/tccl/src/team_lib/sharp/tccl_team_lib_sharp.h
+++ b/tccl/src/team_lib/sharp/tccl_team_lib_sharp.h
@@ -16,7 +16,7 @@ typedef struct tccl_team_lib_sharp {
 } tccl_team_lib_sharp_t;
 
 typedef struct tccl_team_sharp_context {
-    tccl_team_context_t        super;
+    tccl_context_t             super;
     tccl_oob_collectives_t     oob;
     struct sharp_coll_context *sharp_context;
 } tccl_team_sharp_context_t;

--- a/tccl/src/team_lib/tccl_team_lib.c
+++ b/tccl/src/team_lib/tccl_team_lib.c
@@ -4,16 +4,18 @@
 * See file LICENSE for terms.
 */
 
+
 #include "config.h"
+#define _GNU_SOURCE
 #include "tccl_team_lib.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <dlfcn.h>
-#include <link.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <err.h>
+#include <link.h>
+#include <dlfcn.h>
 #include <fts.h>
 
 static int
@@ -36,8 +38,8 @@ static void get_default_lib_path(tccl_lib_t *lib)
     dl_iterate_phdr(callback, (void*)lib);
 }
 
-tccl_status_t tccl_team_lib_init(const char *so_path,
-                                 tccl_team_lib_h *team_lib)
+static tccl_status_t tccl_team_lib_init(const char *so_path,
+                                        tccl_team_lib_h *team_lib)
 {
     char team_lib_struct[128];
     void *handle;
@@ -104,7 +106,7 @@ static void load_team_lib_plugins(tccl_lib_t *lib)
     fts_close(ftsp);
 }
 
-tccl_status_t tccl_team_lib_finalize(tccl_team_lib_h lib) {
+static tccl_status_t tccl_team_lib_finalize(tccl_team_lib_h lib) {
     dlclose(lib);
 }
 
@@ -174,9 +176,9 @@ tccl_status_t tccl_team_lib_query(tccl_team_lib_h team_lib,
     return TCCL_OK;
 }
 
-tccl_status_t tccl_create_team_context(tccl_team_lib_h lib,
-                                       tccl_team_context_config_h config,
-                                       tccl_team_context_h *team_ctx)
+static tccl_status_t tccl_create_team_context(tccl_team_lib_h lib,
+                                              tccl_team_context_config_h config,
+                                              tccl_team_context_h *team_ctx)
 {
     tccl_status_t status;
     status = lib->create_team_context(lib, config, team_ctx);

--- a/tccl/src/team_lib/tccl_team_lib.c
+++ b/tccl/src/team_lib/tccl_team_lib.c
@@ -175,8 +175,8 @@ tccl_status_t tccl_team_lib_query(tccl_team_lib_h team_lib,
 }
 
 tccl_status_t tccl_create_team_context(tccl_team_lib_h lib,
-                                     tccl_team_context_config_h config,
-                                     tccl_team_context_h *team_ctx)
+                                       tccl_team_context_config_h config,
+                                       tccl_team_context_h *team_ctx)
 {
     tccl_status_t status;
     status = lib->create_team_context(lib, config, team_ctx);
@@ -185,6 +185,37 @@ tccl_status_t tccl_create_team_context(tccl_team_lib_h lib,
         memcpy(&((*team_ctx)->cfg), config, sizeof(tccl_team_context_config_t));
     }
     return status;
+}
+
+static tccl_status_t find_tlib_by_name(tccl_lib_t *lib, const char *tlib_name,
+                                       tccl_team_lib_t **tlib) {
+    int i;
+    for (i=0; i<lib->n_libs_opened; i++) {
+        if (0 == strcmp(tlib_name, lib->libs[i]->name)) {
+            *tlib = lib->libs[i];
+            return TCCL_OK;
+        }
+    }
+    *tlib = NULL;
+    return TCCL_ERR_NO_ELEM;
+}
+
+tccl_status_t tccl_create_context(tccl_lib_h lib, tccl_team_context_config_t config,
+                                  tccl_team_context_t **context)
+{
+    tccl_status_t status;
+    if (config.field_mask & TCCL_CONTEXT_CONFIG_FIELD_TEAM_LIB_NAME) {
+        tccl_team_lib_t *tlib;
+        if (TCCL_OK != (status = find_tlib_by_name(lib, config.team_lib_name, &tlib))) {
+            return status;
+        }
+        return tccl_create_team_context(tlib, &config, context);
+    } else {
+        //TODO automatic team lib selection from the list of opened components with
+        // prioritization
+        return TCCL_ERR_NOT_IMPLEMENTED;
+    }
+    return TCCL_OK;
 }
 
 tccl_status_t tccl_destroy_team_context(tccl_team_context_h team_ctx)

--- a/tccl/src/team_lib/tccl_team_lib.c
+++ b/tccl/src/team_lib/tccl_team_lib.c
@@ -188,14 +188,14 @@ tccl_status_t tccl_lib_finalize(tccl_lib_h lib)
 }
 
 static tccl_status_t tccl_create_team_context(tccl_team_lib_h lib,
-                                              tccl_team_context_config_h config,
-                                              tccl_team_context_h *team_ctx)
+                                              tccl_context_config_h config,
+                                              tccl_context_h *team_ctx)
 {
     tccl_status_t status;
     status = lib->create_team_context(lib, config, team_ctx);
     if (TCCL_OK == status) {
         (*team_ctx)->lib = lib;
-        memcpy(&((*team_ctx)->cfg), config, sizeof(tccl_team_context_config_t));
+        memcpy(&((*team_ctx)->cfg), config, sizeof(tccl_context_config_t));
     }
     return status;
 }
@@ -213,8 +213,8 @@ static tccl_status_t find_tlib_by_name(tccl_lib_t *lib, const char *tlib_name,
     return TCCL_ERR_NO_ELEM;
 }
 
-tccl_status_t tccl_create_context(tccl_lib_h lib, tccl_team_context_config_t config,
-                                  tccl_team_context_t **context)
+tccl_status_t tccl_create_context(tccl_lib_h lib, tccl_context_config_t config,
+                                  tccl_context_t **context)
 {
     tccl_status_t status;
     if (config.field_mask & TCCL_CONTEXT_CONFIG_FIELD_TEAM_LIB_NAME) {
@@ -231,12 +231,12 @@ tccl_status_t tccl_create_context(tccl_lib_h lib, tccl_team_context_config_t con
     return TCCL_OK;
 }
 
-tccl_status_t tccl_destroy_context(tccl_team_context_h team_ctx)
+tccl_status_t tccl_destroy_context(tccl_context_h team_ctx)
 {
     return team_ctx->lib->destroy_team_context(team_ctx);
 }
 
-tccl_status_t tccl_team_create_post(tccl_team_context_h team_ctx,
+tccl_status_t tccl_team_create_post(tccl_context_h team_ctx,
                                   tccl_team_config_h config,
                                   tccl_oob_collectives_t oob, tccl_team_h *team)
 {
@@ -280,7 +280,7 @@ tccl_status_t tccl_collective_finalize(tccl_coll_req_h request)
     return request->lib->collective_finalize(request);
 }
 
-tccl_status_t tccl_context_progress(tccl_team_context_h team_ctx)
+tccl_status_t tccl_context_progress(tccl_context_h team_ctx)
 {
     if (team_ctx->lib->progress) {
         return team_ctx->lib->progress(team_ctx);

--- a/tccl/src/team_lib/tccl_team_lib.h
+++ b/tccl/src/team_lib/tccl_team_lib.h
@@ -9,10 +9,11 @@
 #include <string.h>
 
 typedef struct tccl_team_lib {
-    char*                              name;
-    tccl_team_lib_params_t              params;
+    char*                               name;
+    int                                 priority;
+    tccl_lib_config_t                   config;
     tccl_team_lib_context_create_mode_t ctx_create_mode;
-    void*                              dl_handle;
+    void*                               dl_handle;
     tccl_status_t                       (*create_team_context)(tccl_team_lib_h lib,
                                                               tccl_team_context_config_h config,
                                                               tccl_team_context_h *team_context);
@@ -29,6 +30,14 @@ typedef struct tccl_team_lib {
     tccl_status_t                       (*collective_test)(tccl_coll_req_h request);
     tccl_status_t                       (*collective_finalize)(tccl_coll_req_h request);
 } tccl_team_lib_t;
+
+typedef struct tccl_lib {
+    tccl_lib_config_t config_requested;
+    int n_libs_opened;
+    int libs_array_size;
+    char *lib_path;
+    tccl_team_lib_t **libs;
+} tccl_lib_t;
 
 typedef struct tccl_team_context {
     tccl_team_lib_t            *lib;

--- a/tccl/src/team_lib/tccl_team_lib.h
+++ b/tccl/src/team_lib/tccl_team_lib.h
@@ -15,11 +15,11 @@ typedef struct tccl_team_lib {
     tccl_team_lib_context_create_mode_t ctx_create_mode;
     void*                               dl_handle;
     tccl_status_t                       (*create_team_context)(tccl_team_lib_h lib,
-                                                              tccl_team_context_config_h config,
-                                                              tccl_team_context_h *team_context);
-    tccl_status_t                       (*destroy_team_context)(tccl_team_context_h team_context);
-    tccl_status_t                       (*progress)(tccl_team_context_h team_context);
-    tccl_status_t                       (*team_create_post)(tccl_team_context_h team_ctx,
+                                                              tccl_context_config_h config,
+                                                              tccl_context_h *team_context);
+    tccl_status_t                       (*destroy_team_context)(tccl_context_h team_context);
+    tccl_status_t                       (*progress)(tccl_context_h team_context);
+    tccl_status_t                       (*team_create_post)(tccl_context_h team_ctx,
                                                            tccl_team_config_h config,
                                                            tccl_oob_collectives_t oob, tccl_team_h *team);
     tccl_status_t                       (*team_destroy)(tccl_team_h team);
@@ -39,13 +39,13 @@ typedef struct tccl_lib {
     tccl_team_lib_t **libs;
 } tccl_lib_t;
 
-typedef struct tccl_team_context {
+typedef struct tccl_context {
     tccl_team_lib_t            *lib;
-    tccl_team_context_config_t  cfg;
-} tccl_team_context_t;
+    tccl_context_config_t  cfg;
+} tccl_context_t;
 
 typedef struct tccl_team {
-    tccl_team_context_t   *ctx;
+    tccl_context_t   *ctx;
     tccl_team_config_t     cfg;
     tccl_oob_collectives_t oob;
 } tccl_team_t;
@@ -77,7 +77,7 @@ static inline int tccl_team_rank_to_world(tccl_team_config_t *cfg, int rank)
 
 #define TCCL_CONTEXT_SUPER_INIT(_ctx, _lib, _config) do {                \
         (_ctx).lib = (_lib);                                            \
-        memcpy(&((_ctx).cfg), (_config), sizeof(tccl_team_context_config_t)); \
+        memcpy(&((_ctx).cfg), (_config), sizeof(tccl_context_config_t)); \
     }while(0)
 
 #define TCCL_STATIC_ASSERT(_cond) \

--- a/tccl/src/team_lib/ucx/tccl_ucx_context.c
+++ b/tccl/src/team_lib/ucx/tccl_ucx_context.c
@@ -17,8 +17,8 @@ static void tccl_ucx_req_init(void* request)
 
 static void tccl_ucx_req_cleanup(void* request){ }
 
-tccl_status_t tccl_ucx_create_context(tccl_team_lib_t *lib, tccl_team_context_config_t *config,
-                                    tccl_team_context_t **context)
+tccl_status_t tccl_ucx_create_context(tccl_team_lib_t *lib, tccl_context_config_t *config,
+                                      tccl_context_t **context)
 {
     ucp_params_t params;
     ucp_worker_params_t worker_params;
@@ -71,7 +71,7 @@ tccl_status_t tccl_ucx_create_context(tccl_team_lib_t *lib, tccl_team_context_co
     return TCCL_OK;
 }
 
-tccl_status_t tccl_ucx_destroy_context(tccl_team_context_h team_context)
+tccl_status_t tccl_ucx_destroy_context(tccl_context_h team_context)
 {
     tccl_team_lib_ucx_context_t *ctx = tccl_derived_of(team_context, tccl_team_lib_ucx_context_t);
     tccl_oob_collectives_t      *oob = &team_context->cfg.oob;

--- a/tccl/src/team_lib/ucx/tccl_ucx_context.h
+++ b/tccl/src/team_lib/ucx/tccl_ucx_context.h
@@ -7,7 +7,7 @@
 #include "tccl_ucx_lib.h"
 
 typedef struct tccl_team_lib_ucx_context {
-    tccl_team_context_t    super;
+    tccl_context_t        super;
     ucp_ep_h              *ucp_eps;
     ucp_address_t         *worker_address;
     int                   ucx_inited;
@@ -18,8 +18,8 @@ typedef struct tccl_team_lib_ucx_context {
     int                   next_cid;
 } tccl_team_lib_ucx_context_t;
 
-tccl_status_t tccl_ucx_create_context(tccl_team_lib_t *lib, tccl_team_context_config_t *config,
-                                    tccl_team_context_t **context);
-tccl_status_t tccl_ucx_destroy_context(tccl_team_context_t *context);
+tccl_status_t tccl_ucx_create_context(tccl_team_lib_t *lib, tccl_context_config_t *config,
+                                      tccl_context_t **context);
+tccl_status_t tccl_ucx_destroy_context(tccl_context_t *context);
 
 #endif

--- a/tccl/src/team_lib/ucx/tccl_ucx_lib.c
+++ b/tccl/src/team_lib/ucx/tccl_ucx_lib.c
@@ -184,6 +184,12 @@ static tccl_status_t tccl_ucx_collective_finalize(tccl_coll_req_h request)
 
 tccl_team_lib_ucx_t tccl_team_lib_ucx = {
     .super.name                 = "team_lib_ucx",
+    .super.priority             = 10,
+    .super.config.reproducible  = TCCL_LIB_NON_REPRODUCIBLE,
+    .super.config.thread_mode   = TCCL_LIB_THREAD_SINGLE | TCCL_LIB_THREAD_MULTIPLE,
+    .super.config.team_usage    = TCCL_USAGE_SW_COLLECTIVES,
+    .super.config.coll_types    = TCCL_BARRIER | TCCL_FANIN | TCCL_FANOUT |
+                                  TCCL_REDUCE | TCCL_BCAST | TCCL_ALLREDUCE,
     .super.ctx_create_mode      = TCCL_TEAM_LIB_CONTEXT_CREATE_MODE_LOCAL,
     .super.create_team_context  = tccl_ucx_create_context,
     .super.destroy_team_context = tccl_ucx_destroy_context,

--- a/tccl/src/team_lib/ucx/tccl_ucx_lib.c
+++ b/tccl/src/team_lib/ucx/tccl_ucx_lib.c
@@ -183,7 +183,7 @@ static tccl_status_t tccl_ucx_collective_finalize(tccl_coll_req_h request)
 }
 
 tccl_team_lib_ucx_t tccl_team_lib_ucx = {
-    .super.name                 = "team_lib_ucx",
+    .super.name                 = "ucx",
     .super.priority             = 10,
     .super.config.reproducible  = TCCL_LIB_NON_REPRODUCIBLE,
     .super.config.thread_mode   = TCCL_LIB_THREAD_SINGLE | TCCL_LIB_THREAD_MULTIPLE,

--- a/tccl/src/team_lib/ucx/tccl_ucx_team.c
+++ b/tccl/src/team_lib/ucx/tccl_ucx_team.c
@@ -14,7 +14,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-tccl_status_t tccl_ucx_team_create_post(tccl_team_context_t *context, tccl_team_config_t *config,
+tccl_status_t tccl_ucx_team_create_post(tccl_context_t *context, tccl_team_config_t *config,
                                       tccl_oob_collectives_t oob, tccl_team_t **team)
 {
     //TODO need to make this non blocking + team_ucx_wait

--- a/tccl/src/team_lib/ucx/tccl_ucx_team.h
+++ b/tccl/src/team_lib/ucx/tccl_ucx_team.h
@@ -13,7 +13,7 @@ typedef struct tccl_ucx_team_t {
     ucp_ep_h*    ucp_eps;
 } tccl_ucx_team_t;
 
-tccl_status_t tccl_ucx_team_create_post(tccl_team_context_t *context, tccl_team_config_t *config,
+tccl_status_t tccl_ucx_team_create_post(tccl_context_t *context, tccl_team_config_t *config,
                                       tccl_oob_collectives_t oob, tccl_team_t **team);
 tccl_status_t tccl_ucx_team_destroy(tccl_team_t *team);
 

--- a/tccl/src/team_lib/vmc/tccl_team_lib_vmc.c
+++ b/tccl/src/team_lib/vmc/tccl_team_lib_vmc.c
@@ -18,8 +18,8 @@ void tccl_team_vmc_runtime_progress()
 }
 
 tccl_status_t tccl_team_vmc_create_context(tccl_team_lib_h team_lib,
-                                         tccl_team_context_config_h config,
-                                         tccl_team_context_h *team_context)
+                                         tccl_context_config_h config,
+                                         tccl_context_h *team_context)
 {
     tccl_team_vmc_context_t *team_vmc_ctx = malloc(sizeof(*team_vmc_ctx));
     vmc_ctx_params_t       vmc_params;
@@ -41,11 +41,11 @@ tccl_status_t tccl_team_vmc_create_context(tccl_team_lib_h team_lib,
         return TCCL_ERR_NO_MESSAGE;
     }
 
-    *team_context = (tccl_team_context_h)team_vmc_ctx;
+    *team_context = (tccl_context_h)team_vmc_ctx;
     return TCCL_OK;
 }
 
-tccl_status_t tccl_team_vmc_destroy_context(tccl_team_context_h team_context)
+tccl_status_t tccl_team_vmc_destroy_context(tccl_context_h team_context)
 {
     tccl_team_vmc_context_t *team_vmc_ctx = (tccl_team_vmc_context_t*)team_context; 
     
@@ -63,7 +63,7 @@ static int vmc_comm_rank_to_world_mapper(int rank, void *mapper_ctx)
     return tccl_team_rank_to_world(cfg, rank);
 }
 
-tccl_status_t tccl_team_vmc_create_post(tccl_team_context_h team_context,
+tccl_status_t tccl_team_vmc_create_post(tccl_context_h team_context,
                                       tccl_team_config_h config,
                                       tccl_oob_collectives_t oob,
                                       tccl_team_h *team)
@@ -176,7 +176,7 @@ tccl_status_t tccl_team_vmc_collective_finalize(tccl_coll_req_h request)
     return TCCL_OK;
 }
 
-tccl_status_t tccl_team_vmc_context_progress(tccl_team_context_h team_context)
+tccl_status_t tccl_team_vmc_context_progress(tccl_context_h team_context)
 {
     tccl_team_vmc_context_t *team_vmc_ctx = (tccl_team_vmc_context_t*)team_context;
     vmc_progress(team_vmc_ctx->vmc_ctx);

--- a/tccl/src/team_lib/vmc/tccl_team_lib_vmc.c
+++ b/tccl/src/team_lib/vmc/tccl_team_lib_vmc.c
@@ -184,7 +184,7 @@ tccl_status_t tccl_team_vmc_context_progress(tccl_team_context_h team_context)
 }
 
 tccl_team_lib_vmc_t tccl_team_lib_vmc = {
-    .super.name                 = "team_lib_vmc",
+    .super.name                 = "vmc",
     .super.priority             = 10,
     .super.config.reproducible  = TCCL_LIB_NON_REPRODUCIBLE,
     .super.config.thread_mode   = TCCL_LIB_THREAD_SINGLE | TCCL_LIB_THREAD_MULTIPLE,

--- a/tccl/src/team_lib/vmc/tccl_team_lib_vmc.c
+++ b/tccl/src/team_lib/vmc/tccl_team_lib_vmc.c
@@ -185,6 +185,11 @@ tccl_status_t tccl_team_vmc_context_progress(tccl_team_context_h team_context)
 
 tccl_team_lib_vmc_t tccl_team_lib_vmc = {
     .super.name                 = "team_lib_vmc",
+    .super.priority             = 10,
+    .super.config.reproducible  = TCCL_LIB_NON_REPRODUCIBLE,
+    .super.config.thread_mode   = TCCL_LIB_THREAD_SINGLE | TCCL_LIB_THREAD_MULTIPLE,
+    .super.config.team_usage    = TCCL_USAGE_HW_COLLECTIVES,
+    .super.config.coll_types    = TCCL_BCAST,
     .super.ctx_create_mode      = TCCL_TEAM_LIB_CONTEXT_CREATE_MODE_LOCAL,
     .super.create_team_context  = tccl_team_vmc_create_context,
     .super.destroy_team_context = tccl_team_vmc_destroy_context,

--- a/tccl/src/team_lib/vmc/tccl_team_lib_vmc.h
+++ b/tccl/src/team_lib/vmc/tccl_team_lib_vmc.h
@@ -12,7 +12,7 @@ typedef struct tccl_team_lib_vmc {
 } tccl_team_lib_vmc_t;
 
 typedef struct tccl_team_vmc_context {
-    tccl_team_context_t super;
+    tccl_context_t     super;
     vmc_ctx_h          vmc_ctx;
 } tccl_team_vmc_context_t;
 

--- a/tccl/test/Makefile.am
+++ b/tccl/test/Makefile.am
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2020 Mellanox Technologies.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+bin_PROGRAMS = test_mpi_allreduce test_mpi_bcast test_mpi_barrier
+
+test_mpi_allreduce_SOURCES=test_mpi_allreduce.c test_mpi.c
+test_mpi_bcast_SOURCES=test_mpi_bcast.c test_mpi.c
+test_mpi_barrier_SOURCES=test_mpi_barrier.c test_mpi.c
+
+CC=mpicc
+CFLAGS+=-I${includedir} -std=c11
+
+LDFLAGS=-L$(libdir) -ltccl

--- a/tccl/test/test.c
+++ b/tccl/test/test.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
     tccl_lib_h lib;
     tccl_lib_init(lib_config, &lib);
 
-    tccl_team_context_config_t team_ctx_config = {
+    tccl_context_config_t team_ctx_config = {
         .field_mask = TCCL_CONTEXT_CONFIG_FIELD_TEAM_LIB_NAME |
                       TCCL_CONTEXT_CONFIG_FIELD_THREAD_MODE |
                       TCCL_CONTEXT_CONFIG_FIELD_COMPLETION_TYPE,
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
         .thread_mode     = TCCL_LIB_THREAD_SINGLE,
         .completion_type = TCCL_TEAM_COMPLETION_BLOCKING,
     };
-    tccl_team_context_h team_ctx;
+    tccl_context_h team_ctx;
     tccl_create_context(lib, team_ctx_config, &team_ctx);
     return 0;
 }

--- a/tccl/test/test.c
+++ b/tccl/test/test.c
@@ -3,35 +3,28 @@
 *
 * See file LICENSE for terms.
 */
-#include "src/api/tccl.h"
+#include <api/tccl.h>
 #include <stdio.h>
-
-int query_lib_params(tccl_team_lib_h team_lib) {
-    tccl_team_lib_attr_t team_lib_attr;
-    team_lib_attr.field_mask = TCCL_ATTR_FIELD_CONTEXT_CREATE_MODE;
-    tccl_team_lib_query(team_lib, &team_lib_attr);
-    printf("Context create mode: %d(%s)\n", team_lib_attr.context_create_mode,
-        team_lib_attr.context_create_mode ? "global": "local");
-}
 
 int main(int argc, char **argv) {
 
-    tccl_team_lib_params_t lib_params = {
-        .tccl_model_type = TCCL_MODEL_TYPE_MPI,
-        .team_world_size = 8,
-        .team_lib_name = "ucx",
-        .ucp_context = NULL
+    tccl_lib_config_t lib_config = {
+        .field_mask = TCCL_LIB_CONFIG_FIELD_TEAM_USAGE,
+        .team_usage = TCCL_USAGE_SW_COLLECTIVES |
+                      TCCL_USAGE_HW_COLLECTIVES,
     };
-    tccl_team_lib_h lib;
-    tccl_team_lib_init(&lib_params, &lib);
-    query_lib_params(lib);
+    tccl_lib_h lib;
+    tccl_lib_init(lib_config, &lib);
 
     tccl_team_context_config_t team_ctx_config = {
-        .thread_support = TCCL_THREAD_MODE_PRIVATE,
-        .completion_type = TCCL_TEAM_COMPLETION_BLOCKING
+        .field_mask = TCCL_CONTEXT_CONFIG_FIELD_TEAM_LIB_NAME |
+                      TCCL_CONTEXT_CONFIG_FIELD_THREAD_MODE |
+                      TCCL_CONTEXT_CONFIG_FIELD_COMPLETION_TYPE,
+        .team_lib_name   = "ucx",
+        .thread_mode     = TCCL_LIB_THREAD_SINGLE,
+        .completion_type = TCCL_TEAM_COMPLETION_BLOCKING,
     };
     tccl_team_context_h team_ctx;
-    tccl_create_team_context(lib, &team_ctx_config, &team_ctx);
-
+    tccl_create_context(lib, team_ctx_config, &team_ctx);
     return 0;
 }

--- a/tccl/test/test_mpi.c
+++ b/tccl/test/test_mpi.c
@@ -1,47 +1,39 @@
-/**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
-*
-* See file LICENSE for terms.
-*/
-#include <mpi.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-#include "api/tccl.h"
+#include "test_mpi.h"
 
-#define STR(x) # x
-#define TCCL_CHECK(_call) if (TCCL_OK != (_call)) {\
-        fprintf(stderr, "fail: %s\n", STR(_call)); \
-        exit(-1);                                  \
-    }
+tccl_team_h tccl_world_team;
+
+static tccl_lib_h lib;
+static tccl_team_context_h team_ctx;
 
 static int oob_allgather(void *sbuf, void *rbuf, size_t len, void *coll_context) {
     MPI_Comm comm = (MPI_Comm)coll_context;
     MPI_Allgather(sbuf, len, MPI_BYTE, rbuf, len, MPI_BYTE, comm);
     return 0;
 }
-int main (int argc, char **argv) {
-    int rank, size;
+
+int tccl_mpi_test_init(int argc, char **argv) {
     char *var;
+    int rank, size;
+
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 
+    /* Init tccl library */
     var = getenv("TCCL_TEST_TEAM");
     tccl_lib_config_t lib_config = {
         .field_mask = TCCL_LIB_CONFIG_FIELD_TEAM_USAGE,
         .team_usage = TCCL_USAGE_SW_COLLECTIVES |
-                      TCCL_USAGE_HW_COLLECTIVES,
+        TCCL_USAGE_HW_COLLECTIVES,
     };
-    tccl_lib_h lib;
-    tccl_lib_init(lib_config, &lib);
+    TCCL_CHECK(tccl_lib_init(lib_config, &lib));
 
+    /* Init tccl context for a specified TCCL_TEST_TEAM */
     tccl_team_context_config_t team_ctx_config = {
         .field_mask = TCCL_CONTEXT_CONFIG_FIELD_TEAM_LIB_NAME |
-                      TCCL_CONTEXT_CONFIG_FIELD_THREAD_MODE |
-                      TCCL_CONTEXT_CONFIG_FIELD_OOB |
-                      TCCL_CONTEXT_CONFIG_FIELD_COMPLETION_TYPE,
+        TCCL_CONTEXT_CONFIG_FIELD_THREAD_MODE |
+        TCCL_CONTEXT_CONFIG_FIELD_OOB |
+        TCCL_CONTEXT_CONFIG_FIELD_COMPLETION_TYPE,
         .team_lib_name   = var ? var : "ucx",
         .thread_mode     = TCCL_LIB_THREAD_SINGLE,
         .completion_type = TCCL_TEAM_COMPLETION_BLOCKING,
@@ -52,8 +44,10 @@ int main (int argc, char **argv) {
             .size         = size
         },
     };
+    TCCL_CHECK(tccl_create_context(lib, team_ctx_config, &team_ctx));
+
 #if 0
-    //TODO
+    //TODO need to discuss where this should go
     tccl_team_lib_attr_t team_lib_attr;
     team_lib_attr.field_mask = TCCL_ATTR_FIELD_CONTEXT_CREATE_MODE;
     tccl_team_lib_query(lib, &team_lib_attr);
@@ -68,69 +62,33 @@ int main (int argc, char **argv) {
         team_ctx_config.oob = oob_ctx;
     }
 #endif    
-    tccl_team_context_h team_ctx;
-    TCCL_CHECK(tccl_create_context(lib, team_ctx_config, &team_ctx));
-    {
-        /* Create TEAM for comm world */
-        tccl_team_config_t team_config = {
-            .team_size = size,
-            .team_rank = rank,
-            .range     = {
-                .type           = TCCL_EP_RANGE_STRIDED,
-                .strided.start  = 0,
-                .strided.stride = 1
-            }
-        };
 
-        tccl_oob_collectives_t oob = {
-            .allgather  = oob_allgather,
-            .coll_context = (void*)MPI_COMM_WORLD,
-            .rank = rank,
-            .size = size
-        };
+    /* Create TCCL TEAM for comm world */
+    tccl_team_config_t team_config = {
+        .team_size = size,
+        .team_rank = rank,
+        .range     = {
+            .type           = TCCL_EP_RANGE_STRIDED,
+            .strided.start  = 0,
+            .strided.stride = 1
+        }
+    };
 
-        tccl_team_h world_team;
-        tccl_team_create_post(team_ctx, &team_config, oob, &world_team);
-        const int count =32;
-        int sbuf[count], rbuf[count], rbuf_mpi[count];
-        int i;
-        for (i=0; i<count; i++) {
-            rbuf[i] = 0;
-            sbuf[i] = rank+1+12345 + i;
-        }
-        tccl_coll_req_h request;
-        tccl_coll_op_args_t coll = {
-            .coll_type = TCCL_ALLREDUCE,
-            .buffer_info = {
-                .src_buffer = sbuf,
-                .dst_buffer = rbuf,
-                .len        = count*sizeof(int),
-            },
-            .reduce_info = {
-                .dt = TCCL_DT_INT32,
-                .op = TCCL_OP_SUM,
-                .count = count,
-            },
-            .alg.set_by_user = 0,
-            .tag  = 123, //todo
-        };
-        tccl_collective_init(&coll, &request, world_team);
-        tccl_collective_post(request);
-        tccl_collective_wait(request);
-        tccl_collective_finalize(request);
-        tccl_team_destroy(world_team);
+    tccl_oob_collectives_t oob = {
+        .allgather  = oob_allgather,
+        .coll_context = (void*)MPI_COMM_WORLD,
+        .rank = rank,
+        .size = size
+    };
 
-        MPI_Allreduce(sbuf, rbuf_mpi, count, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
-        int status = 0, status_global;
-        if (0 != memcmp(rbuf, rbuf_mpi, count*sizeof(int))) {
-            fprintf(stderr, "RST CHECK FAILURE at rank %d\n", rank);
-            status = 1;
-        }
-        MPI_Reduce(&status, &status_global, 1, MPI_INT, MPI_MAX, 0, MPI_COMM_WORLD);
-        if (0 == rank) {
-            printf("Correctness check: %s\n", status_global == 0 ? "PASS" : "FAIL");
-        }
-    }
-    tccl_destroy_team_context(team_ctx);
+    TCCL_CHECK(tccl_team_create_post(team_ctx, &team_config, oob, &tccl_world_team));
+    return 0;
+}
+
+int tccl_mpi_test_finalize(void) {
+    TCCL_CHECK(tccl_team_destroy(tccl_world_team));
+    TCCL_CHECK(tccl_destroy_context(team_ctx));
+    TCCL_CHECK(tccl_lib_finalize(lib));
     MPI_Finalize();
+    return 0;
 }

--- a/tccl/test/test_mpi.c
+++ b/tccl/test/test_mpi.c
@@ -3,7 +3,7 @@
 tccl_team_h tccl_world_team;
 
 static tccl_lib_h lib;
-static tccl_team_context_h team_ctx;
+static tccl_context_h team_ctx;
 
 static int oob_allgather(void *sbuf, void *rbuf, size_t len, void *coll_context) {
     MPI_Comm comm = (MPI_Comm)coll_context;
@@ -29,7 +29,7 @@ int tccl_mpi_test_init(int argc, char **argv) {
     TCCL_CHECK(tccl_lib_init(lib_config, &lib));
 
     /* Init tccl context for a specified TCCL_TEST_TEAM */
-    tccl_team_context_config_t team_ctx_config = {
+    tccl_context_config_t team_ctx_config = {
         .field_mask = TCCL_CONTEXT_CONFIG_FIELD_TEAM_LIB_NAME |
         TCCL_CONTEXT_CONFIG_FIELD_THREAD_MODE |
         TCCL_CONTEXT_CONFIG_FIELD_OOB |

--- a/tccl/test/test_mpi.h
+++ b/tccl/test/test_mpi.h
@@ -1,0 +1,19 @@
+#ifndef TEST_MPI_H
+#define TEST_MPI_H
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <mpi.h>
+#include <api/tccl.h>
+#define STR(x) # x
+#define TCCL_CHECK(_call) if (TCCL_OK != (_call)) {\
+        fprintf(stderr, "fail: %s\n", STR(_call)); \
+        exit(-1);                                  \
+    }
+
+extern tccl_team_h tccl_world_team;
+int tccl_mpi_test_init(int argc, char **argv);
+int tccl_mpi_test_finalize(void);
+
+#endif

--- a/tccl/test/test_mpi_allreduce.c
+++ b/tccl/test/test_mpi_allreduce.c
@@ -1,0 +1,58 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+#include "test_mpi.h"
+
+int main (int argc, char **argv) {
+    const int count = 32;
+    tccl_coll_req_h request;
+    int rank, size, i, status = 0, status_global;
+    int sbuf[count], rbuf[count], rbuf_mpi[count];
+
+    tccl_mpi_test_init(argc, argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    for (i=0; i<count; i++) {
+        rbuf[i] = 0;
+        sbuf[i] = rank+1+12345 + i;
+    }
+
+    tccl_coll_op_args_t coll = {
+        .coll_type = TCCL_ALLREDUCE,
+        .buffer_info = {
+            .src_buffer = sbuf,
+            .dst_buffer = rbuf,
+            .len        = count*sizeof(int),
+        },
+        .reduce_info = {
+            .dt = TCCL_DT_INT32,
+            .op = TCCL_OP_SUM,
+            .count = count,
+        },
+        .alg.set_by_user = 0,
+        .tag  = 123, //todo
+    };
+
+    tccl_collective_init(&coll, &request, tccl_world_team);
+    tccl_collective_post(request);
+    tccl_collective_wait(request);
+    tccl_collective_finalize(request);
+
+    MPI_Allreduce(sbuf, rbuf_mpi, count, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+
+    if (0 != memcmp(rbuf, rbuf_mpi, count*sizeof(int))) {
+        fprintf(stderr, "RST CHECK FAILURE at rank %d\n", rank);
+        status = 1;
+    }
+
+    MPI_Reduce(&status, &status_global, 1, MPI_INT, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (0 == rank) {
+        printf("Correctness check: %s\n", status_global == 0 ? "PASS" : "FAIL");
+    }
+
+    tccl_mpi_test_finalize();
+    return 0;
+}

--- a/tccl/test/test_mpi_barrier.c
+++ b/tccl/test/test_mpi_barrier.c
@@ -3,18 +3,7 @@
 *
 * See file LICENSE for terms.
 */
-#include <mpi.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-#include "api/tccl.h"
-
-static int oob_allgather(void *sbuf, void *rbuf, size_t len, void *coll_context) {
-    MPI_Comm comm = (MPI_Comm)coll_context;
-    MPI_Allgather(sbuf, len, MPI_BYTE, rbuf, len, MPI_BYTE, comm);
-    return 0;
-}
+#include "test_mpi.h"
 
 static inline void
 do_barrier(tccl_team_h team) {
@@ -31,71 +20,23 @@ do_barrier(tccl_team_h team) {
 }
 
 int main (int argc, char **argv) {
-    int rank, size;
-    char *var;
-    MPI_Init(&argc, &argv);
+    int rank, size, i, sleep_us;
+
+    tccl_mpi_test_init(argc, argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 
-    var = getenv("TCCL_TEST_TEAM");
-    tccl_team_lib_params_t lib_params = {
-        .tccl_model_type = TCCL_MODEL_TYPE_MPI,
-        .team_lib_name = var ? var : "ucx",
-        .ucp_context = NULL
-    };
-    tccl_team_lib_h lib;
-    tccl_team_lib_init(&lib_params, &lib);
-
-    tccl_team_context_config_t team_ctx_config = {
-        .thread_support = TCCL_THREAD_MODE_PRIVATE,
-        .completion_type = TCCL_TEAM_COMPLETION_BLOCKING
-    };
-    tccl_team_lib_attr_t team_lib_attr;
-    team_lib_attr.field_mask = TCCL_ATTR_FIELD_CONTEXT_CREATE_MODE;
-    tccl_team_lib_query(lib, &team_lib_attr);
-    if (team_lib_attr.context_create_mode == TCCL_TEAM_LIB_CONTEXT_CREATE_MODE_GLOBAL) {
-        tccl_oob_collectives_t oob_ctx = {
-            .allgather  = oob_allgather,
-            .coll_context = (void*)MPI_COMM_WORLD,
-            .rank = rank,
-            .size = size
-        };
-
-        team_ctx_config.oob = oob_ctx;
-    }
-    tccl_team_context_h team_ctx;
-    tccl_create_team_context(lib, &team_ctx_config, &team_ctx);
-    {
-        /* Create TEAM for comm world */
-        tccl_team_config_t team_config = {
-            .team_size = size,
-            .team_rank = rank,
-        };
-
-        tccl_oob_collectives_t oob = {
-            .allgather  = oob_allgather,
-            .coll_context = (void*)MPI_COMM_WORLD,
-            .rank = rank,
-            .size = size
-        };
-
-        tccl_team_h world_team;
-        tccl_team_create_post(team_ctx, &team_config, oob, &world_team);
-        int i;
-        srand(time(NULL));
-        for (i=0; i<size; i++) {
-            int sleep_us = rand() % 1000;
-            usleep(sleep_us);
-            if (i == rank) {
-                printf("Rank %d checks in\n", rank);
-                fflush(stdout);
-                usleep(100);
-            }
-            do_barrier(world_team);
+    srand(time(NULL));
+    for (i=0; i<size; i++) {
+        sleep_us = rand() % 1000;
+        usleep(sleep_us);
+        if (i == rank) {
+            printf("Rank %d checks in\n", rank);
+            fflush(stdout);
+            usleep(100);
         }
-        tccl_team_destroy(world_team);
+        do_barrier(tccl_world_team);
     }
 
-
-    MPI_Finalize();
+    tccl_mpi_test_finalize();
 }

--- a/tccl/test/test_mpi_bcast.c
+++ b/tccl/test/test_mpi_bcast.c
@@ -3,117 +3,60 @@
 *
 * See file LICENSE for terms.
 */
-#include <mpi.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-#include "api/tccl.h"
+#include "test_mpi.h"
 
-static int oob_allgather(void *sbuf, void *rbuf, size_t len, void *coll_context) {
-    MPI_Comm comm = (MPI_Comm)coll_context;
-    MPI_Allgather(sbuf, len, MPI_BYTE, rbuf, len, MPI_BYTE, comm);
-    return 0;
-}
 int main (int argc, char **argv) {
-    int rank, size;
-    char *var;
-    MPI_Init(&argc, &argv);
+    const int count =32;
+    int rank, size, i, r, status = 0, status_global;
+    int buf[count], buf_mpi[count];
+    tccl_coll_req_h request;    
+    tccl_mpi_test_init(argc, argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 
-    var = getenv("TCCL_TEST_TEAM");
-    tccl_team_lib_params_t lib_params = {
-        .tccl_model_type = TCCL_MODEL_TYPE_MPI,
-        .team_lib_name = var ? var : "ucx",
-        .ucp_context = NULL
-    };
-    tccl_team_lib_h lib;
-    tccl_team_lib_init(&lib_params, &lib);
-
-    tccl_team_context_config_t team_ctx_config = {
-        .thread_support = TCCL_THREAD_MODE_PRIVATE,
-        .completion_type = TCCL_TEAM_COMPLETION_BLOCKING
-    };
-    tccl_team_lib_attr_t team_lib_attr;
-    team_lib_attr.field_mask = TCCL_ATTR_FIELD_CONTEXT_CREATE_MODE;
-    tccl_team_lib_query(lib, &team_lib_attr);
-    if (team_lib_attr.context_create_mode == TCCL_TEAM_LIB_CONTEXT_CREATE_MODE_GLOBAL) {
-        tccl_oob_collectives_t oob_ctx = {
-            .allgather  = oob_allgather,
-            .coll_context = (void*)MPI_COMM_WORLD,
-            .rank = rank,
-            .size = size
-        };
-
-        team_ctx_config.oob = oob_ctx;
-    }
-    tccl_team_context_h team_ctx;
-    tccl_create_team_context(lib, &team_ctx_config, &team_ctx);
-    {
-        /* Create TEAM for comm world */
-        tccl_team_config_t team_config = {
-            .team_size = size,
-            .team_rank = rank,
-        };
-
-        tccl_oob_collectives_t oob = {
-            .allgather  = oob_allgather,
-            .coll_context = (void*)MPI_COMM_WORLD,
-            .rank = rank,
-            .size = size
-        };
-
-        tccl_team_h world_team;
-        tccl_team_create_post(team_ctx, &team_config, oob, &world_team);
-        const int count =32;
-        int buf[count], buf_mpi[count];
-        int i, r;
-        int status = 0, status_global;
-        for (r=0; r<size; r++) {
-            if (rank != r) {
-                memset(buf, 0, sizeof(buf));
-                memset(buf_mpi, 0, sizeof(buf_mpi));
-            } else {
-                for (i=0; i<count; i++) {
-                    buf[i] = buf_mpi[i] = rank+1+12345 + i;
-                }
-            }
-            tccl_coll_req_h request;
-            tccl_coll_op_args_t coll = {
-                .coll_type = TCCL_BCAST,
-                .root = r,
-                .buffer_info = {
-                    .src_buffer = buf,
-                    .dst_buffer = buf,
-                    .len        = count*sizeof(int),
-                },
-                .alg.set_by_user = 1,
-                .alg.id          = 1,
-                .tag  = 123, //todo
-            };
-            tccl_collective_init(&coll, &request, world_team);
-            tccl_collective_post(request);
-            tccl_collective_wait(request);
-            tccl_collective_finalize(request);
-
-            MPI_Bcast(buf_mpi, count, MPI_INT, r, MPI_COMM_WORLD);
-
-            if (0 != memcmp(buf, buf_mpi, count*sizeof(int))) {
-                fprintf(stderr, "RST CHECK FAILURE at rank %d\n", rank);
-                status = 1;
-            }
-            MPI_Allreduce(&status, &status_global, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
-
-            if (0 != status_global) {
-                break;
+    for (r=0; r<size; r++) {
+        if (rank != r) {
+            memset(buf, 0, sizeof(buf));
+            memset(buf_mpi, 0, sizeof(buf_mpi));
+        } else {
+            for (i=0; i<count; i++) {
+                buf[i] = buf_mpi[i] = rank+1+12345 + i;
             }
         }
-        tccl_team_destroy(world_team);
 
-        if (0 == rank) {
-            printf("Correctness check: %s\n", status_global == 0 ? "PASS" : "FAIL");
+        tccl_coll_op_args_t coll = {
+            .coll_type = TCCL_BCAST,
+            .root = r,
+            .buffer_info = {
+                .src_buffer = buf,
+                .dst_buffer = buf,
+                .len        = count*sizeof(int),
+            },
+            .alg.set_by_user = 1,
+            .alg.id          = 1,
+            .tag  = 123, //todo
+        };
+
+        tccl_collective_init(&coll, &request, tccl_world_team);
+        tccl_collective_post(request);
+        tccl_collective_wait(request);
+        tccl_collective_finalize(request);
+
+        MPI_Bcast(buf_mpi, count, MPI_INT, r, MPI_COMM_WORLD);
+        if (0 != memcmp(buf, buf_mpi, count*sizeof(int))) {
+            fprintf(stderr, "RST CHECK FAILURE at rank %d\n", rank);
+            status = 1;
+        }
+        MPI_Allreduce(&status, &status_global, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+        if (0 != status_global) {
+            break;
         }
     }
-    MPI_Finalize();
+
+    if (0 == rank) {
+        printf("Correctness check: %s\n", status_global == 0 ? "PASS" : "FAIL");
+    }
+
+    tccl_mpi_test_finalize();
+    return 0;
 }


### PR DESCRIPTION
- Follows the discussion and changes in the API 
- Single wrapper library that automatically loads all the available team_lib plugins
- new tccl_lib_config_t and filtering of the plugins based on capabilities required vs available
- Rename: tccl_team_context_t -> tccl_context_t
- Fix tccl tests accordingly
- tccl_lib_finalize
- the specification of the plugin happens at context creation
- adds the necessary corresponding MCCL changes