### PR TITLE
Nb team create

### DIFF
--- a/ompi_coll_xccl.patch
+++ b/ompi_coll_xccl.patch
@@ -1,7 +1,7 @@
 From 1b969299a8ae1d4d289cd4bcc6b124ed30943e39 Mon Sep 17 00:00:00 2001
 From: Valentin Petrov <valentinp@mellanox.com>
 Date: Mon, 2 Mar 2020 13:26:33 +0200
-Subject: [PATCH] ompi/coll/xccl
+Subject: [PATCH 1/3] ompi/coll/xccl
 
     eXperimental openucx collective communication library (XCCL)
     integration layer
@@ -1070,6 +1070,195 @@ index 0000000..cdf5a1e
 +    AC_SUBST([coll_xccl_LDFLAGS])
 +    AC_SUBST([coll_xccl_LIBS])
 +])dnl
+-- 
+2.6.2
+
+
+From 75b19a87b550f5fed52358492da164b3886460b1 Mon Sep 17 00:00:00 2001
+From: Valentin Petrov <valentinp@mellanox.com>
+Date: Tue, 17 Mar 2020 22:18:46 +0200
+Subject: [PATCH 2/3] coll/xccl: non blocking oob allgather interface
+
+---
+ ompi/mca/coll/xccl/coll_xccl_module.c | 121 +++++++++++++++++++++++++---------
+ 1 file changed, 89 insertions(+), 32 deletions(-)
+
+diff --git a/ompi/mca/coll/xccl/coll_xccl_module.c b/ompi/mca/coll/xccl/coll_xccl_module.c
+index 9dc07e2..a71956e 100644
+--- a/ompi/mca/coll/xccl/coll_xccl_module.c
++++ b/ompi/mca/coll/xccl/coll_xccl_module.c
+@@ -106,42 +106,95 @@ static int xccl_comm_attr_del_fn(MPI_Comm comm, int keyval, void *attr_val, void
+     return OMPI_SUCCESS;
+ }
+ 
+-
+-static int oob_allgather(void *sbuf, void *rbuf, size_t msglen,
+-                          int my_rank, xccl_ep_range_t range,  void *oob_coll_ctx) {
+-    ompi_communicator_t *comm = (ompi_communicator_t *)oob_coll_ctx;
++typedef struct oob_allgather_req{
++    xccl_ep_range_t range;
++    void *sbuf;
++    void *rbuf;
++    void *oob_coll_ctx;
++    int my_rank;
++    size_t msglen;
++    int iter;
++    ompi_request_t *reqs[2];
++} oob_allgather_req_t;
++
++static xccl_status_t oob_allgather_test(void *req)
++{
++    oob_allgather_req_t *oob_req = (oob_allgather_req_t*)req;
++    int rank, size, sendto, recvfrom, recvdatafrom, senddatafrom, completed, probe;
++    char *tmpsend = NULL, *tmprecv = NULL;
++    size_t msglen = oob_req->msglen;
++    const int probe_count = 1;
++    ompi_communicator_t *comm = (ompi_communicator_t *)oob_req->oob_coll_ctx;
+     if (!comm) comm = &ompi_mpi_comm_world.comm;
+-    if (XCCL_EP_RANGE_UNDEFINED == range.type) {
+-        comm->c_coll->coll_allgather(sbuf, msglen, MPI_BYTE,
+-                                     rbuf, msglen, MPI_BYTE, comm,
+-                                     comm->c_coll->coll_allgather_module);
++    if (oob_req->range.type == XCCL_EP_RANGE_UNDEFINED) {
++        size = ompi_comm_size(comm);
++        rank = ompi_comm_rank(comm);
+     } else {
+-        int root = xccl_range_to_rank(range, 0);
+-        if (my_rank == root) {
+-            int i;
+-            memcpy(rbuf, sbuf, msglen);
+-            for (i=1; i<range.ep_num; i++) {
+-                MCA_PML_CALL(recv((void*)((char*)rbuf + msglen*i), msglen,
+-                                  MPI_BYTE, xccl_range_to_rank(range, i),
+-                                  MCA_COLL_BASE_TAG_XCCL,
+-                                  comm, MPI_STATUS_IGNORE));
+-            }
+-            for (i=1; i<range.ep_num; i++) {
+-                MCA_PML_CALL(send(rbuf, msglen*range.ep_num, MPI_BYTE,
+-                                  xccl_range_to_rank(range, i),
+-                                  MCA_COLL_BASE_TAG_XCCL,
+-                                  MCA_PML_BASE_SEND_STANDARD, comm));
++        size = oob_req->range.ep_num;
++        rank = oob_req->my_rank;
++    }
++    if (oob_req->iter == 0) {
++        tmprecv = (char*) oob_req->rbuf + (ptrdiff_t)rank * (ptrdiff_t)msglen;
++        memcpy(tmprecv, oob_req->sbuf, msglen);
++    }
++    sendto = (rank + 1) % size;
++    recvfrom  = (rank - 1 + size) % size;
++    if (oob_req->range.type != XCCL_EP_RANGE_UNDEFINED) {
++        sendto = xccl_range_to_rank(oob_req->range, sendto);
++        recvfrom = xccl_range_to_rank(oob_req->range, recvfrom);
++    }
++    for (; oob_req->iter < size - 1; oob_req->iter++) {
++        if (oob_req->iter > 0) {
++            probe = 0;
++            do {
++                ompi_request_test_all(2, oob_req->reqs, &completed, MPI_STATUS_IGNORE);
++                probe++;
++            } while (!completed && probe < probe_count);
++            if (!completed) {
++                return XCCL_INPROGRESS;
+             }
+-        } else {
+-            MCA_PML_CALL(send(sbuf, msglen, MPI_BYTE, root,
+-                              MCA_COLL_BASE_TAG_XCCL,
+-                              MCA_PML_BASE_SEND_STANDARD, comm));
+-            MCA_PML_CALL(recv(rbuf, msglen*range.ep_num, MPI_BYTE, root,
+-                              MCA_COLL_BASE_TAG_XCCL,
+-                              comm, MPI_STATUS_IGNORE));
+         }
++        recvdatafrom = (rank - oob_req->iter - 1 + size) % size;
++        senddatafrom = (rank - oob_req->iter + size) % size;
++        tmprecv = (char*)oob_req->rbuf + (ptrdiff_t)recvdatafrom * (ptrdiff_t)msglen;
++        tmpsend = (char*)oob_req->rbuf + (ptrdiff_t)senddatafrom * (ptrdiff_t)msglen;
++
++        MCA_PML_CALL(isend(tmpsend, msglen, MPI_BYTE, sendto, MCA_COLL_BASE_TAG_XCCL,
++                           MCA_PML_BASE_SEND_STANDARD, comm, &oob_req->reqs[0]));
++        MCA_PML_CALL(irecv(tmprecv, msglen, MPI_BYTE, recvfrom,
++                           MCA_COLL_BASE_TAG_XCCL, comm, &oob_req->reqs[1]));
++    }
++    probe = 0;
++    do {
++        ompi_request_test_all(2, oob_req->reqs, &completed, MPI_STATUS_IGNORE);
++        probe++;
++    } while (!completed && probe < probe_count);
++    if (!completed) {
++        return XCCL_INPROGRESS;
+     }
+-    return 0;
++    return XCCL_OK;
++}
++
++static xccl_status_t oob_allgather_free(void *req)
++{
++    free(req);
++    return XCCL_OK;
++}
++
++static xccl_status_t oob_allgather(void *sbuf, void *rbuf, size_t msglen,
++                                   int my_rank, xccl_ep_range_t range,
++                                   void *oob_coll_ctx, void **req)
++{
++    oob_allgather_req_t *oob_req = malloc(sizeof(*oob_req));
++    oob_req->sbuf = sbuf;
++    oob_req->rbuf = rbuf;
++    oob_req->msglen = msglen;
++    oob_req->range = range;
++    oob_req->oob_coll_ctx = oob_coll_ctx;
++    oob_req->my_rank = my_rank;
++    oob_req->iter = 0;
++    *req = oob_req;
++    return oob_allgather_test(*req);
+ }
+ 
+ /*
+@@ -175,6 +228,8 @@ static int mca_coll_xccl_module_enable(mca_coll_base_module_t *module,
+                 .completion_type = XCCL_TEAM_COMPLETION_BLOCKING,
+                 .oob = {
+                     .allgather    = oob_allgather,
++                    .req_test     = oob_allgather_test,
++                    .req_free     = oob_allgather_free,
+                     .coll_context = (void*)MPI_COMM_WORLD,
+                     .rank         = ompi_comm_rank(&ompi_mpi_comm_world.comm),
+                     .size         = ompi_comm_size(&ompi_mpi_comm_world.comm)
+@@ -216,7 +271,9 @@ static int mca_coll_xccl_module_enable(mca_coll_base_module_t *module,
+     };
+ 
+     xccl_oob_collectives_t oob = {
+-        .allgather  = oob_allgather,
++        .allgather    = oob_allgather,
++        .req_test     = oob_allgather_test,
++        .req_free     = oob_allgather_free,
+         .coll_context = (void*)comm,
+         .rank = ompi_comm_rank(comm),
+         .size = ompi_comm_size(comm)
+-- 
+2.6.2
+
+
+From 7812b664c13a3fc3be7393252677fa4656d8dece Mon Sep 17 00:00:00 2001
+From: Valentin Petrov <valentinp@mellanox.com>
+Date: Wed, 18 Mar 2020 11:27:09 +0200
+Subject: [PATCH 3/3] coll/xccl: wait for team creation completion
+
+---
+ ompi/mca/coll/xccl/coll_xccl_module.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/ompi/mca/coll/xccl/coll_xccl_module.c b/ompi/mca/coll/xccl/coll_xccl_module.c
+index a71956e..9d8446e 100644
+--- a/ompi/mca/coll/xccl/coll_xccl_module.c
++++ b/ompi/mca/coll/xccl/coll_xccl_module.c
+@@ -291,6 +291,7 @@ static int mca_coll_xccl_module_enable(mca_coll_base_module_t *module,
+         }
+         return OMPI_ERROR;
+     }
++    while (XCCL_INPROGRESS == xccl_team_create_test(*team)) {;}
+ 
+     if (OMPI_SUCCESS != mca_coll_xccl_save_coll_handlers((mca_coll_xccl_module_t *)module)){
+         XCCL_ERROR("coll_xccl: mca_coll_xccl_save_coll_handlers failed");
 -- 
 2.6.2
 

--- a/src/api/xccl.h
+++ b/src/api/xccl.h
@@ -216,7 +216,7 @@ typedef struct xccl_team_config {
 xccl_status_t xccl_team_create_post(xccl_context_h team_ctx,
                                     xccl_team_config_h config,
                                     xccl_oob_collectives_t oob, xccl_team_h *team);
-
+xccl_status_t xccl_team_create_test(xccl_team_h team);
 xccl_status_t xccl_team_destroy(xccl_team_h team);
 
 typedef enum {

--- a/src/api/xccl.h
+++ b/src/api/xccl.h
@@ -131,7 +131,9 @@ static inline int xccl_range_to_rank(xccl_ep_range_t range, int rank)
 typedef struct xccl_oob_collectives {
     int (*allgather)(void *src_buf, void *recv_buff, size_t size,
                      int my_rank, xccl_ep_range_t range,
-                     void *coll_context);
+                     void *coll_context, void **request);
+    xccl_status_t (*req_test)(void *request);
+    xccl_status_t (*req_free)(void *request);
     void *coll_context;
     int rank;
     int size;

--- a/src/core/xccl_collective.c
+++ b/src/core/xccl_collective.c
@@ -13,6 +13,7 @@
 xccl_status_t xccl_collective_init(xccl_coll_op_args_t *coll_args,
                                    xccl_coll_req_h *request, xccl_team_h team)
 {
+    XCCL_CHECK_TEAM(team);
     int tl_team_id = team->coll_team_id[coll_args->coll_type];
     xccl_tl_team_t *tl_team = team->tl_teams[tl_team_id];
     xccl_team_lib_t *lib = tl_team->ctx->lib;
@@ -55,6 +56,7 @@ xccl_status_t xccl_context_progress(xccl_context_h context)
 xccl_status_t xccl_global_mem_map_start(xccl_team_h team, xccl_mem_map_params_t params,
                                         xccl_mem_h *memh_p)
 {
+    XCCL_CHECK_TEAM(team);
     xccl_status_t status;
     int i;
     xccl_team_lib_t *tl;

--- a/src/core/xccl_finalize.c
+++ b/src/core/xccl_finalize.c
@@ -13,7 +13,6 @@
 #include <dlfcn.h>
 
 extern xccl_lib_t xccl_static_lib;
-extern xccl_lib_config_t xccl_lib_global_config;
 extern ucs_config_field_t xccl_lib_global_config_table[];
 
 xccl_status_t xccl_team_lib_finalize(xccl_team_lib_h lib)

--- a/src/core/xccl_team_lib.h
+++ b/src/core/xccl_team_lib.h
@@ -100,10 +100,13 @@ typedef struct xccl_team {
 static inline void
 xccl_oob_allgather(void *sbuf, void* rbuf, size_t len, xccl_oob_collectives_t *oob)
 {
+    void *req;
     xccl_ep_range_t r = {
         .type = XCCL_EP_RANGE_UNDEFINED,
     };
-    oob->allgather(sbuf, rbuf, len, 0, r, oob->coll_context);
+    oob->allgather(sbuf, rbuf, len, 0, r, oob->coll_context, &req);
+    while (XCCL_INPROGRESS == oob->req_test(req)) {;}
+    oob->req_free(req);
 }
 
 xccl_status_t xccl_create_context(xccl_lib_t *lib,

--- a/src/team_lib/hier/xccl_hier_lib.c
+++ b/src/team_lib/hier/xccl_hier_lib.c
@@ -159,6 +159,7 @@ xccl_team_lib_hier_t xccl_team_lib_hier = {
     .super.create_team_context  = xccl_hier_create_context,
     .super.destroy_team_context = xccl_hier_destroy_context,
     .super.team_create_post     = xccl_hier_team_create_post,
+    .super.team_create_test     = xccl_hier_team_create_test,
     .super.team_destroy         = xccl_hier_team_destroy,
     .super.progress             = xccl_hier_context_progress,
     .super.team_lib_open        = NULL,

--- a/src/team_lib/hier/xccl_hier_team.c
+++ b/src/team_lib/hier/xccl_hier_team.c
@@ -26,7 +26,7 @@ static int xccl_sbgp_rank_to_team(int rank, void *rank_mapper_ctx) {
 
 static int
 oob_sbgp_allgather(void *sbuf, void *rbuf, size_t len,
-                   int myrank, xccl_ep_range_t r, void *coll_context) {
+                   int myrank, xccl_ep_range_t r, void *coll_context, void **req) {
     sbgp_t *sbgp = (sbgp_t*)coll_context;
     xccl_hier_team_t *team = sbgp->hier_team;
     assert(r.type == XCCL_EP_RANGE_UNDEFINED);
@@ -36,8 +36,8 @@ oob_sbgp_allgather(void *sbuf, void *rbuf, size_t len,
         .cb.cb     = xccl_sbgp_rank_to_team,
         .cb.cb_ctx = (void*)sbgp,
     };
-    team->super.oob.allgather(sbuf, rbuf, len, team->super.oob.rank,
-                              range, team->super.oob.coll_context);
+    team->super.oob.allgather(sbuf, rbuf, len, sbgp->group_rank,
+                              range, team->super.oob.coll_context, req);
     return 0;
 }
 

--- a/src/team_lib/hier/xccl_hier_team.c
+++ b/src/team_lib/hier/xccl_hier_team.c
@@ -117,6 +117,12 @@ xccl_status_t xccl_hier_team_create_post(xccl_tl_context_t *context, xccl_team_c
     return XCCL_OK;
 }
 
+xccl_status_t xccl_hier_team_create_test(xccl_tl_team_t *team)
+{
+    /*TODO implement true non-blocking */
+    return XCCL_OK;
+}
+
 xccl_status_t xccl_hier_team_destroy(xccl_tl_team_t *team)
 {
     xccl_hier_team_t *hier_team = xccl_derived_of(team, xccl_hier_team_t);

--- a/src/team_lib/hier/xccl_hier_team.h
+++ b/src/team_lib/hier/xccl_hier_team.h
@@ -34,7 +34,9 @@ typedef struct xccl_hier_team {
 
 xccl_status_t xccl_hier_team_create_post(xccl_tl_context_t *context, xccl_team_config_t *config,
                                          xccl_oob_collectives_t oob, xccl_tl_team_t **team);
+xccl_status_t xccl_hier_team_create_test(xccl_tl_team_t *team);
 xccl_status_t xccl_hier_team_destroy(xccl_tl_team_t *team);
+
 
 static inline int xccl_hier_team_rank2ctx(xccl_hier_team_t *team, int rank)
 {

--- a/src/team_lib/sharp/xccl_sharp_lib.c
+++ b/src/team_lib/sharp/xccl_sharp_lib.c
@@ -178,6 +178,12 @@ xccl_sharp_team_create_post(xccl_tl_context_t *context,
     return XCCL_OK;
 }
 
+static xccl_status_t xccl_sharp_team_create_test(xccl_tl_team_t *team)
+{
+    /*TODO implement true non-blocking */
+    return XCCL_OK;
+}
+
 static xccl_status_t xccl_sharp_team_destroy(xccl_tl_team_t *team)
 {
     xccl_sharp_team_t *team_sharp = xccl_derived_of(team, xccl_sharp_team_t);
@@ -210,6 +216,7 @@ xccl_team_lib_sharp_t xccl_team_lib_sharp = {
     .super.create_team_context  = xccl_sharp_create_context,
     .super.destroy_team_context = xccl_sharp_destroy_context,
     .super.team_create_post     = xccl_sharp_team_create_post,
+    .super.team_create_test     = xccl_sharp_team_create_test,
     .super.team_destroy         = xccl_sharp_team_destroy,
     .super.progress             = NULL,
     .super.team_lib_open        = NULL,

--- a/src/team_lib/ucx/xccl_ucx_ep.h
+++ b/src/team_lib/ucx/xccl_ucx_ep.h
@@ -35,14 +35,14 @@ static inline xccl_status_t close_eps(ucp_ep_h *eps, int n_eps, ucp_worker_h wor
 
 static inline xccl_status_t
 connect_ep(xccl_team_lib_ucx_context_t *ctx, xccl_ucx_team_t *team,
-           xccl_team_config_t *cfg, char *addr_array, size_t max_addrlen, int rank)
+           char *addr_array, size_t max_addrlen, int rank)
 {
     ucp_address_t *address = (ucp_address_t*)(addr_array + max_addrlen*rank);
     ucp_ep_params_t ep_params;
     ucs_status_t status;
     ucp_ep_h *ep;
     if (ctx->ucp_eps) {
-        ep = &ctx->ucp_eps[xccl_range_to_rank(cfg->range, rank)];
+        ep = &ctx->ucp_eps[xccl_range_to_rank(team->range, rank)];
     } else {
         ep = &team->ucp_eps[rank];
     }

--- a/src/team_lib/ucx/xccl_ucx_lib.c
+++ b/src/team_lib/ucx/xccl_ucx_lib.c
@@ -229,6 +229,7 @@ xccl_team_lib_ucx_t xccl_team_lib_ucx = {
     .super.create_team_context  = xccl_ucx_create_context,
     .super.destroy_team_context = xccl_ucx_destroy_context,
     .super.team_create_post     = xccl_ucx_team_create_post,
+    .super.team_create_test     = xccl_ucx_team_create_test,
     .super.team_destroy         = xccl_ucx_team_destroy,
     .super.progress             = NULL,
     .super.collective_init      = xccl_ucx_collective_init,

--- a/src/team_lib/ucx/xccl_ucx_team.c
+++ b/src/team_lib/ucx/xccl_ucx_team.c
@@ -14,10 +14,15 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+struct xccl_ucx_nb_create_req {
+    int phase;
+    void *scratch;
+    void *allgather_req;
+};
+
 xccl_status_t xccl_ucx_team_create_post(xccl_tl_context_t *context, xccl_team_config_t *config,
                                         xccl_oob_collectives_t oob, xccl_tl_team_t **team)
 {
-    //TODO need to make this non blocking + team_ucx_wait
     xccl_status_t status      = XCCL_OK;
     xccl_team_lib_ucx_context_t *ctx =
         xccl_derived_of(context, xccl_team_lib_ucx_context_t);
@@ -27,45 +32,87 @@ xccl_status_t xccl_ucx_team_create_post(xccl_tl_context_t *context, xccl_team_co
     int *tmp;
     int local_addrlen, i, sbuf[2];
     char* addr_array;
-
+    struct xccl_ucx_nb_create_req *nb_req = malloc(sizeof(*nb_req));
     ucx_team = (xccl_ucx_team_t*)malloc(sizeof(xccl_ucx_team_t));
     XCCL_TEAM_SUPER_INIT(ucx_team->super, context, config, oob);
-
+    nb_req->phase = 0;
+    ucx_team->nb_create_req  = nb_req;
+    ucx_team->range          = config->range;
     local_addrlen            = (int)ctx->ucp_addrlen;
     tmp                      = (int*)malloc(size*sizeof(int)*2);
     sbuf[0]                  = local_addrlen;
     sbuf[1]                  = ctx->next_cid;
-    xccl_oob_allgather(sbuf, tmp, 2*sizeof(int), &oob);
-    for (i=0; i<size; i++) {
-        if (tmp[2*i] > max_addrlen) max_addrlen = tmp[2*i];
-        if (tmp[2*i+1] > max_cid)   max_cid     = tmp[2*i+1];
-    }
-    free(tmp);
-
-    ucx_team->ctx_id  = (uint16_t)max_cid; // TODO check overflow
-    ucx_team->seq_num = 0;
-    ctx->next_cid     = max_cid + 1; // this is only a tmp solution to max_cid
-                                     // need another alg for cid allocatoin or
-                                     // and interface to get from user
-    addr_array        = (char*)malloc(size*max_addrlen);
-    xccl_oob_allgather(ctx->worker_address, addr_array, max_addrlen, &oob);
-
-    if (!ctx->ucp_eps) {
-        ucx_team->ucp_eps = (ucp_ep_h*)calloc(size, sizeof(ucp_ep_h));
-    } else {
-        ucx_team->ucp_eps = NULL;
-    }
-
-    for (i=0; i<size; i++) {
-        if (XCCL_OK != (status = connect_ep(ctx, ucx_team, config,
-                                           addr_array, max_addrlen, i))) {
-            goto cleanup;
-        }
-    }
+    xccl_oob_allgather_nb(sbuf, tmp, 2*sizeof(int), &oob, &nb_req->allgather_req);
+    nb_req->scratch = tmp;
     *team = &ucx_team->super;
+    return XCCL_OK;
+}
+
+xccl_status_t xccl_ucx_team_create_test(xccl_tl_team_t *team)
+{
+    xccl_status_t status      = XCCL_OK;
+    xccl_team_lib_ucx_context_t *ctx =
+        xccl_derived_of(team->ctx, xccl_team_lib_ucx_context_t);
+    xccl_oob_collectives_t oob = team->oob;
+    int max_cid = 0, size = oob.size,
+        rank = oob.rank;
+    xccl_ucx_team_t *ucx_team = xccl_derived_of(team, xccl_ucx_team_t);
+    int *tmp;
+    int local_addrlen, i, sbuf[2];
+    char* addr_array;
+    struct xccl_ucx_nb_create_req *nb_req =
+        (struct xccl_ucx_nb_create_req *)ucx_team->nb_create_req;
+    if (NULL == nb_req) {
+        return XCCL_OK;
+    } else if (XCCL_INPROGRESS == oob.req_test(nb_req->allgather_req)) {
+        return XCCL_INPROGRESS;
+    }
+    oob.req_free(nb_req->allgather_req);
+
+    switch (nb_req->phase) {
+    case 0:
+        tmp = (int*)nb_req->scratch;
+        ucx_team->max_addrlen = 0;
+        for (i=0; i<size; i++) {
+            if (tmp[2*i] > ucx_team->max_addrlen) ucx_team->max_addrlen = tmp[2*i];
+            if (tmp[2*i+1] > max_cid)   max_cid     = tmp[2*i+1];
+        }
+        free(tmp);
+
+        ucx_team->ctx_id  = (uint16_t)max_cid; // TODO check overflow
+        ucx_team->seq_num = 0;
+        ctx->next_cid     = max_cid + 1; // this is only a tmp solution to max_cid
+                                         // need another alg for cid allocatoin or
+                                         // and interface to get from user
+        addr_array        = (char*)malloc(size*ucx_team->max_addrlen);
+        xccl_oob_allgather_nb(ctx->worker_address, addr_array,
+                              ucx_team->max_addrlen, &oob, &nb_req->allgather_req);
+        nb_req->phase = 1;
+        nb_req->scratch = addr_array;
+        return XCCL_INPROGRESS;
+    case 1:
+        addr_array = (char*)nb_req->scratch;
+        if (!ctx->ucp_eps) {
+            ucx_team->ucp_eps = (ucp_ep_h*)calloc(size, sizeof(ucp_ep_h));
+        } else {
+            ucx_team->ucp_eps = NULL;
+        }
+
+        for (i=0; i<size; i++) {
+            if (XCCL_OK != (status = connect_ep(ctx, ucx_team,
+                                                addr_array, ucx_team->max_addrlen, i))) {
+                status = XCCL_ERR_NO_MESSAGE;
+                goto cleanup;
+            }
+        }
+        break;
+    }
+
 cleanup:
     free(addr_array);
-    return XCCL_OK;
+    free(nb_req);
+    ucx_team->nb_create_req = NULL;
+    return status;
 }
 
 xccl_status_t xccl_ucx_team_destroy(xccl_tl_team_t *team)

--- a/src/team_lib/ucx/xccl_ucx_team.h
+++ b/src/team_lib/ucx/xccl_ucx_team.h
@@ -10,11 +10,14 @@ typedef struct xccl_ucx_team_t {
     xccl_tl_team_t   super;
     uint16_t         ctx_id;
     uint16_t         seq_num;
+    int              max_addrlen;
     ucp_ep_h        *ucp_eps;
+    xccl_ep_range_t  range;
+    void            *nb_create_req;
 } xccl_ucx_team_t;
 
 xccl_status_t xccl_ucx_team_create_post(xccl_tl_context_t *context, xccl_team_config_t *config,
                                         xccl_oob_collectives_t oob, xccl_tl_team_t **team);
+xccl_status_t xccl_ucx_team_create_test(xccl_tl_team_t *team);
 xccl_status_t xccl_ucx_team_destroy(xccl_tl_team_t *team);
-
 #endif

--- a/src/team_lib/vmc/xccl_vmc_lib.c
+++ b/src/team_lib/vmc/xccl_vmc_lib.c
@@ -98,6 +98,12 @@ static xccl_status_t xccl_vmc_team_create_post(xccl_tl_context_t *context,
     return XCCL_OK;
 }
 
+static xccl_status_t xccl_vmc_team_create_test(xccl_tl_team_t *team)
+{
+    /*TODO implement true non-blocking */
+    return XCCL_OK;
+}
+
 static xccl_status_t xccl_vmc_team_destroy(xccl_tl_team_t *team)
 {
     xccl_vmc_team_t *team_vmc = xccl_derived_of(team, xccl_vmc_team_t);
@@ -183,6 +189,7 @@ xccl_team_lib_vmc_t xccl_team_lib_vmc = {
     .super.create_team_context  = xccl_vmc_create_context,
     .super.destroy_team_context = xccl_vmc_destroy_context,
     .super.team_create_post     = xccl_vmc_team_create_post,
+    .super.team_create_test     = xccl_vmc_team_create_test,
     .super.team_destroy         = xccl_vmc_team_destroy,
     .super.progress             = xccl_vmc_context_progress,
     .super.team_lib_open        = NULL,

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -7,12 +7,17 @@
 # $HEADER$
 #
 
-bin_PROGRAMS = test_mpi_allreduce test_mpi_bcast test_mpi_barrier test_mpi_fanout_get
+bin_PROGRAMS =  test_mpi_allreduce \
+				test_mpi_bcast \
+				test_mpi_barrier \
+				test_mpi_fanout_get \
+				test_mpi_create_team_nb
 
 test_mpi_allreduce_SOURCES=test_mpi_allreduce.c test_mpi.c
 test_mpi_bcast_SOURCES=test_mpi_bcast.c test_mpi.c
 test_mpi_barrier_SOURCES=test_mpi_barrier.c test_mpi.c
 test_mpi_fanout_get_SOURCES=test_mpi_fanout_get.c test_mpi.c
+test_mpi_create_team_nb_SOURCES=test_mpi_create_team_nb.c test_mpi.c
 
 CC=mpicc
 CFLAGS+=-I${includedir} -std=c11

--- a/test/test_mpi.c
+++ b/test/test_mpi.c
@@ -3,33 +3,95 @@
 xccl_team_h xccl_world_team;
 static xccl_context_h team_ctx;
 
-static int oob_allgather(void *sbuf, void *rbuf, size_t msglen,
-                         int my_rank, xccl_ep_range_t range,
-                         void *coll_context) {
-    MPI_Comm comm = (MPI_Comm)coll_context;
-    if (XCCL_EP_RANGE_UNDEFINED == range.type) {
-        MPI_Allgather(sbuf, msglen, MPI_BYTE, rbuf, msglen, MPI_BYTE, comm);
+typedef struct xccl_test_oob_allgather_req {
+    xccl_ep_range_t range;
+    void *sbuf;
+    void *rbuf;
+    void *oob_coll_ctx;
+    int my_rank;
+    size_t msglen;
+    int iter;
+    MPI_Request reqs[2];
+} xccl_test_oob_allgather_req_t;
+
+static xccl_status_t oob_allgather_test(void *req)
+{
+    xccl_test_oob_allgather_req_t *oob_req =
+        (xccl_test_oob_allgather_req_t*)req;
+    int rank, size, sendto, recvfrom, recvdatafrom, senddatafrom, completed, probe;
+    char *tmpsend = NULL, *tmprecv = NULL;
+    size_t msglen = oob_req->msglen;
+    const int probe_count = 1;
+    MPI_Comm comm = (MPI_Comm)oob_req->oob_coll_ctx;
+
+    if (oob_req->range.type == XCCL_EP_RANGE_UNDEFINED) {
+        MPI_Comm_size(comm, &size);
+        MPI_Comm_rank(comm, &rank);
     } else {
-        int root = xccl_range_to_rank(range, 0);
-        if (my_rank == root) {
-            int i;
-            memcpy(rbuf, sbuf, msglen);
-            for (i=1; i<range.ep_num; i++) {
-                MPI_Recv((void*)((char*)rbuf + msglen*i), msglen,
-                         MPI_BYTE, xccl_range_to_rank(range, i), 123,
-                         comm, MPI_STATUS_IGNORE);
-            }
-            for (i=1; i<range.ep_num; i++) {
-                MPI_Send(rbuf, msglen*range.ep_num, MPI_BYTE,
-                         xccl_range_to_rank(range, i), 123, comm);
-            }
-        } else {
-            MPI_Send(sbuf, msglen, MPI_BYTE, root, 123, comm);
-            MPI_Recv(rbuf, msglen*range.ep_num, MPI_BYTE, root,
-                     123, comm, MPI_STATUS_IGNORE);
-        }
+        size = oob_req->range.ep_num;
+        rank = oob_req->my_rank;
     }
-    return 0;
+    if (oob_req->iter == 0) {
+        tmprecv = (char*) oob_req->rbuf + (ptrdiff_t)rank * (ptrdiff_t)msglen;
+        memcpy(tmprecv, oob_req->sbuf, msglen);
+    }
+    sendto = (rank + 1) % size;
+    recvfrom  = (rank - 1 + size) % size;
+    if (oob_req->range.type != XCCL_EP_RANGE_UNDEFINED) {
+        sendto = xccl_range_to_rank(oob_req->range, sendto);
+        recvfrom = xccl_range_to_rank(oob_req->range, recvfrom);
+    }
+    for (; oob_req->iter < size - 1; oob_req->iter++) {
+        if (oob_req->iter > 0) {
+            probe = 0;
+            do {
+                MPI_Testall(2, oob_req->reqs, &completed, MPI_STATUS_IGNORE);
+                probe++;
+            } while (!completed && probe < probe_count);
+            if (!completed) {
+                return XCCL_INPROGRESS;
+            }
+        }
+        recvdatafrom = (rank - oob_req->iter - 1 + size) % size;
+        senddatafrom = (rank - oob_req->iter + size) % size;
+        tmprecv = (char*)oob_req->rbuf + (ptrdiff_t)recvdatafrom * (ptrdiff_t)msglen;
+        tmpsend = (char*)oob_req->rbuf + (ptrdiff_t)senddatafrom * (ptrdiff_t)msglen;
+        MPI_Isend(tmpsend, msglen, MPI_BYTE, sendto, 123,
+                  comm, &oob_req->reqs[0]);
+        MPI_Irecv(tmprecv, msglen, MPI_BYTE, recvfrom, 123,
+                  comm, &oob_req->reqs[1]);
+    }
+    probe = 0;
+    do {
+        MPI_Testall(2, oob_req->reqs, &completed, MPI_STATUS_IGNORE);
+        probe++;
+    } while (!completed && probe < probe_count);
+    if (!completed) {
+        return XCCL_INPROGRESS;
+    }
+    return XCCL_OK;
+}
+
+static xccl_status_t oob_allgather_free(void *req)
+{
+    free(req);
+    return XCCL_OK;
+}
+
+static xccl_status_t oob_allgather(void *sbuf, void *rbuf, size_t msglen,
+                                   int my_rank, xccl_ep_range_t range,
+                                   void *oob_coll_ctx, void **req)
+{
+    xccl_test_oob_allgather_req_t *oob_req = malloc(sizeof(*oob_req));
+    oob_req->sbuf = sbuf;
+    oob_req->rbuf = rbuf;
+    oob_req->msglen = msglen;
+    oob_req->range = range;
+    oob_req->oob_coll_ctx = oob_coll_ctx;
+    oob_req->my_rank = my_rank;
+    oob_req->iter = 0;
+    *req = oob_req;
+    return oob_allgather_test(*req);
 }
 
 int xccl_mpi_test_init(int argc, char **argv,
@@ -60,6 +122,8 @@ int xccl_mpi_test_init(int argc, char **argv,
             .completion_type = XCCL_TEAM_COMPLETION_BLOCKING,
             .oob = {
                 .allgather    = oob_allgather,
+                .req_test     = oob_allgather_test,
+                .req_free     = oob_allgather_free,
                 .coll_context = (void*)MPI_COMM_WORLD,
                 .rank         = rank,
                 .size         = size
@@ -95,7 +159,9 @@ int xccl_mpi_test_init(int argc, char **argv,
     };
 
     xccl_oob_collectives_t oob = {
-        .allgather  = oob_allgather,
+        .allgather    = oob_allgather,
+        .req_test     = oob_allgather_test,
+        .req_free     = oob_allgather_free,
         .coll_context = (void*)MPI_COMM_WORLD,
         .rank = rank,
         .size = size

--- a/test/test_mpi.h
+++ b/test/test_mpi.h
@@ -16,5 +16,6 @@ extern xccl_team_h xccl_world_team;
 int xccl_mpi_test_init(int argc, char **argv,
                        xccl_collective_cap_t coll_types);
 int xccl_mpi_test_finalize(void);
+int xccl_mpi_create_comm_nb(MPI_Comm comm, xccl_team_h *team);
 
 #endif

--- a/test/test_mpi_create_team_nb.c
+++ b/test/test_mpi_create_team_nb.c
@@ -1,0 +1,43 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+#include "test_mpi.h"
+
+int main (int argc, char **argv) {
+    int rank, size;
+    int sbuf, rbuf;
+
+    XCCL_CHECK(xccl_mpi_test_init(argc, argv, XCCL_COLL_CAP_ALLREDUCE));
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    MPI_Comm split_comm;
+    xccl_team_h split_team;
+    MPI_Comm_split(MPI_COMM_WORLD, rank % 2, rank, &split_comm);
+    int split_rank, split_size;
+    MPI_Comm_rank(split_comm, &split_rank);
+    MPI_Comm_size(split_comm, &split_size);
+
+    if (split_rank % 2 == 0) {
+        MPI_Sendrecv(&sbuf, 1, MPI_INT, (split_rank + 1) % split_size, 123,
+                     &rbuf, 1, MPI_INT, (split_rank + split_size - 1) % split_size, 123,
+                     split_comm, MPI_STATUS_IGNORE);
+        xccl_mpi_create_comm_nb(split_comm, &split_team);
+    } else {
+        xccl_mpi_create_comm_nb(split_comm, &split_team);
+        MPI_Sendrecv(&sbuf, 1, MPI_INT, (split_rank + 1) % split_size, 123,
+                     &rbuf, 1, MPI_INT, (split_rank + split_size - 1) % split_size, 123,
+                     split_comm, MPI_STATUS_IGNORE);
+    }
+    while (XCCL_INPROGRESS == xccl_team_create_test(split_team)) {;};
+    XCCL_CHECK(xccl_team_destroy(split_team));
+        MPI_Comm_free(&split_comm);
+    if (0 == rank) {
+        printf("Correctness check: %s\n", "PASS");
+    }
+
+    XCCL_CHECK(xccl_mpi_test_finalize());
+    return 0;
+}


### PR DESCRIPTION
Implementation of the non-blocking team creation interface:
1. Added the xccl_team_test API. xccl_team_create_post returns initialized team pointer but it is not ready for use. User has to test the completion of the team_create process with the xccl_team_test API. This makes the process non-blocking.
2. In order to achieve that the OOB allgather is changed: it returns void * request object. Additionally 2 more APIs are provided by the runtime as part of OOB: request_test (tests the completion of nb oob allgather), requst_free.
3. Each team_lib now can take advantage of the NB interface and add the non-blocking implementation of its team creation. This is added for ucx team_lib. (sharp, vmc - todo).
4. Added xccl test that checks the non-blocking semantics of team_create_post (currently it'll pass for XCCL_TEST_TLS=ucx, but it'll hang for others - because other team_libs don't implement it).
5. ompi/coll/xccl component is updated to reflect the changes (ompi_coll_xccl.path)