### PR TITLE
Team sharp reg cache

### DIFF
--- a/m4/sharp.m4
+++ b/m4/sharp.m4
@@ -37,20 +37,22 @@ AS_IF([test "x$with_sharp" != "xno"],
                             sharp_happy="no"])
             ], [sharp_happy="no"])
 
-        CFLAGS="$save_CFLAGS"
-        CPPFLAGS="$save_CPPFLAGS"
-        LDFLAGS="$save_LDFLAGS"
 
         AS_IF([test "x$sharp_happy" = "xyes"],
             [
                 AC_SUBST(SHARP_CPPFLAGS, "-I$xccl_check_sharp_dir/include/ ")
                 AC_SUBST(SHARP_LDFLAGS, "-lsharp_coll -L$xccl_check_sharp_dir/lib")
+                AC_CHECK_MEMBERS([struct sharp_coll_init_spec.oob_ctx, struct sharp_coll_reduce_spec.aggr_mode,
+                                  struct sharp_coll_data_desc.mem_type], [], [],  [[#include <sharp/api/sharp_coll.h>]])
             ],
             [
                 AS_IF([test "x$with_sharp" != "xguess"],
                     [AC_MSG_ERROR([SHARP support is requested but SHARP packages cannot be found])],
                     [AC_MSG_WARN([SHARP not found])])
             ])
+        CFLAGS="$save_CFLAGS"
+        CPPFLAGS="$save_CPPFLAGS"
+        LDFLAGS="$save_LDFLAGS"
 
     ],
     [AC_MSG_WARN([SHARP was explicitly disabled])])

--- a/src/core/xccl_finalize.c
+++ b/src/core/xccl_finalize.c
@@ -6,8 +6,6 @@
 
 #include "config.h"
 #include "xccl_team_lib.h"
-#include <ucs/config/parser.h>
-#include <ucs/sys/compiler.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <dlfcn.h>

--- a/src/core/xccl_init.c
+++ b/src/core/xccl_init.c
@@ -8,7 +8,8 @@
 #define _GNU_SOURCE
 #include "xccl_team_lib.h"
 #include <ucs/config/parser.h>
-#include <ucs/sys/compiler.h>
+#include <ucs/sys/preprocessor.h>
+#include <ucs/sys/compiler_def.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/core/xccl_team_lib.h
+++ b/src/core/xccl_team_lib.h
@@ -6,6 +6,7 @@
 #ifndef XCCL_TEAM_LIB_H_
 #define XCCL_TEAM_LIB_H_
 
+#include "config.h"
 #include "api/xccl.h"
 #include "api/xccl_tls.h"
 #include <assert.h>

--- a/src/team_lib/sharp/xccl_sharp_collective.c
+++ b/src/team_lib/sharp/xccl_sharp_collective.c
@@ -23,7 +23,7 @@ xccl_sharp_mem_rcache_reg(xccl_sharp_context_t *ctx, void *address,
     }
 
     *rregion = (xccl_sharp_rcache_region_t*)region;
-    return UCS_OK;
+    return XCCL_OK;
 }
 
 static void xccl_sharp_mem_rcache_dereg(xccl_sharp_context_t *ctx,

--- a/src/team_lib/sharp/xccl_sharp_collective.c
+++ b/src/team_lib/sharp/xccl_sharp_collective.c
@@ -39,6 +39,25 @@ xccl_sharp_allreduce_post(xccl_sharp_coll_req_t *req)
                                       &req->reduce_spec, &req->handle);
 }
 
+static inline xccl_status_t
+xccl_sharp_get_free_buf(xccl_sharp_team_t *team_sharp,
+                        xccl_sharp_buf_t **buffer)
+{
+    unsigned bcopy_buf_num = xccl_team_lib_sharp.config.bcopy_buf_num;
+    xccl_sharp_buf_t *buf;
+    int              i;
+
+    for(i = 0; i < bcopy_buf_num; i++) {
+        buf = team_sharp->bufs + i;
+        if (buf->used == 0) {
+            buf->used = 1;
+            *buffer = buf;
+            return XCCL_OK;
+        }
+    }
+    return XCCL_ERR_NO_RESOURCE;
+}
+
 static xccl_status_t
 xccl_sharp_allreduce_init(xccl_coll_op_args_t* coll_args,
                           xccl_coll_req_h *request,
@@ -49,10 +68,16 @@ xccl_sharp_allreduce_init(xccl_coll_op_args_t* coll_args,
     enum sharp_datatype   sharp_type      = xccl_to_sharp_dtype[coll_args->reduce_info.dt];
     enum sharp_reduce_op  sharp_op        = xccl_to_sharp_reduce_op[coll_args->reduce_info.op];
     xccl_sharp_context_t  *team_sharp_ctx = xccl_derived_of(team->ctx, xccl_sharp_context_t);
+    unsigned              bcopy_buf_num   = xccl_team_lib_sharp.config.bcopy_buf_num;
+    size_t                bcopy_buf_size  = xccl_team_lib_sharp.config.zcopy_thresh;
+
     struct sharp_coll_reduce_spec *reduce_spec;
     xccl_status_t                 status;
     void                          *src_mr, *dst_mr;
+    void                          *src_buf, *dst_buf;
     int                           rc;
+    xccl_status_t                 use_free_buf;
+    xccl_sharp_buf_t              *sharp_buf;
 
     if (sharp_type == SHARP_DTYPE_NULL || sharp_op == SHARP_OP_NULL) {
         return XCCL_ERR_NOT_IMPLEMENTED;
@@ -62,46 +87,70 @@ xccl_sharp_allreduce_init(xccl_coll_op_args_t* coll_args,
     req->super.lib  = &xccl_team_lib_sharp.super;
     req->team       = team_sharp;
     
-    if (team_sharp_ctx->rcache == NULL) {
-        rc = sharp_coll_reg_mr(team_sharp_ctx->sharp_context,
-                               coll_args->buffer_info.src_buffer,
-                               coll_args->buffer_info.len, &src_mr);
-        if (rc != SHARP_COLL_SUCCESS) {
-            xccl_sharp_error("SHARP regmr failed for src buffer\n");
-        }
-        rc = sharp_coll_reg_mr(team_sharp_ctx->sharp_context,
-                               coll_args->buffer_info.dst_buffer,
-                               coll_args->buffer_info.len, &dst_mr);
-        if (rc != SHARP_COLL_SUCCESS) {
-            xccl_sharp_error("SHARP regmr failed for dst buffer\n");
-        }
-    } else {
-        status = xccl_sharp_mem_rcache_reg(team_sharp_ctx,
-                                           coll_args->buffer_info.src_buffer,
-                                           coll_args->buffer_info.len,
-                                           &req->src_rregion);
-        if (status != XCCL_OK) {
-            xccl_sharp_error("SHARP regmr failed for src buffer\n");
-        }
-        src_mr = req->src_rregion->memh;
-
-        status = xccl_sharp_mem_rcache_reg(team_sharp_ctx,
-                                           coll_args->buffer_info.dst_buffer,
-                                           coll_args->buffer_info.len,
-                                           &req->dst_rregion);
-        if (status != XCCL_OK) {
-            xccl_sharp_error("SHARP regmr failed for dst buffer\n");
-        }
-        dst_mr = req->dst_rregion->memh;
+    use_free_buf = XCCL_ERR_NO_RESOURCE;
+    if (coll_args->buffer_info.len <= bcopy_buf_size) {
+        use_free_buf =xccl_sharp_get_free_buf(team_sharp, &sharp_buf);
     }
 
-    req->reduce_spec.sbuf_desc.buffer.ptr        = coll_args->buffer_info.src_buffer;
+    if (use_free_buf == XCCL_OK) {
+        xccl_sharp_trace("sharp bcopy is used");
+        memcpy(sharp_buf->buf, coll_args->buffer_info.src_buffer,
+               coll_args->buffer_info.len);
+        req->sharp_buf               = sharp_buf;
+        req->sharp_buf->orig_src_buf = coll_args->buffer_info.src_buffer;
+        req->sharp_buf->orig_dst_buf = coll_args->buffer_info.dst_buffer;
+        src_buf = sharp_buf->buf;
+        dst_buf = sharp_buf->buf + bcopy_buf_size;
+        src_mr  = sharp_buf->mr;
+        dst_mr  = sharp_buf->mr;
+    }
+    else {
+        if (team_sharp_ctx->rcache == NULL) {
+            xccl_sharp_trace("sharp direct registration is used");
+            rc = sharp_coll_reg_mr(team_sharp_ctx->sharp_context,
+                                coll_args->buffer_info.src_buffer,
+                                coll_args->buffer_info.len, &src_mr);
+            if (rc != SHARP_COLL_SUCCESS) {
+                xccl_sharp_error("SHARP regmr failed for src buffer\n");
+            }
+            rc = sharp_coll_reg_mr(team_sharp_ctx->sharp_context,
+                                coll_args->buffer_info.dst_buffer,
+                                coll_args->buffer_info.len, &dst_mr);
+            if (rc != SHARP_COLL_SUCCESS) {
+                xccl_sharp_error("SHARP regmr failed for dst buffer\n");
+            }
+        } else {
+            xccl_sharp_trace("sharp registration cache is used");
+            status = xccl_sharp_mem_rcache_reg(team_sharp_ctx,
+                                            coll_args->buffer_info.src_buffer,
+                                            coll_args->buffer_info.len,
+                                            &req->src_rregion);
+            if (status != XCCL_OK) {
+                xccl_sharp_error("SHARP regmr failed for src buffer\n");
+            }
+            src_mr = req->src_rregion->memh;
+
+            status = xccl_sharp_mem_rcache_reg(team_sharp_ctx,
+                                            coll_args->buffer_info.dst_buffer,
+                                            coll_args->buffer_info.len,
+                                            &req->dst_rregion);
+            if (status != XCCL_OK) {
+                xccl_sharp_error("SHARP regmr failed for dst buffer\n");
+            }
+            dst_mr = req->dst_rregion->memh;
+        }
+        src_buf = coll_args->buffer_info.src_buffer;
+        dst_buf = coll_args->buffer_info.dst_buffer;
+        req->sharp_buf = NULL;
+    }
+
+    req->reduce_spec.sbuf_desc.buffer.ptr        = src_buf;
     req->reduce_spec.sbuf_desc.buffer.mem_handle = src_mr;
     req->reduce_spec.sbuf_desc.buffer.length     = coll_args->buffer_info.len;
     req->reduce_spec.sbuf_desc.type              = SHARP_DATA_BUFFER;
     req->reduce_spec.sbuf_desc.mem_type          = SHARP_MEM_TYPE_HOST;
  
-    req->reduce_spec.rbuf_desc.buffer.ptr        = coll_args->buffer_info.dst_buffer;
+    req->reduce_spec.rbuf_desc.buffer.ptr        = dst_buf;
     req->reduce_spec.rbuf_desc.buffer.mem_handle = dst_mr;
     req->reduce_spec.rbuf_desc.buffer.length     = coll_args->buffer_info.len;
     req->reduce_spec.rbuf_desc.type              = SHARP_DATA_BUFFER;
@@ -141,7 +190,8 @@ xccl_sharp_barrier_init(xccl_coll_op_args_t *coll_args,
     req->team       = team_sharp;
     req->start      = xccl_sharp_barrier_post;
     req->coll_type  = XCCL_BARRIER;
-
+    req->sharp_buf  = NULL;
+    
     *request = &req->super;
     return XCCL_OK;
 }
@@ -182,6 +232,12 @@ xccl_status_t xccl_sharp_collective_test(xccl_coll_req_h request)
     int completed;
 
     completed = sharp_coll_req_test(req->handle);
+    if ((req->coll_type != XCCL_BARRIER) && (completed == 1) &&
+        (req->sharp_buf != NULL)) {
+        memcpy(req->sharp_buf->orig_dst_buf,
+               req->reduce_spec.rbuf_desc.buffer.ptr,
+               req->reduce_spec.rbuf_desc.buffer.length);
+    }
     return (completed) ? XCCL_OK : XCCL_INPROGRESS;
 }
 
@@ -191,11 +247,18 @@ xccl_status_t xccl_sharp_collective_finalize(xccl_coll_req_h request)
     xccl_sharp_team_t     *team = req->team;
     xccl_sharp_context_t  *ctx  = xccl_derived_of(team->super.ctx,
                                                   xccl_sharp_context_t);
-    int           rc;
+    int rc;
 
     sharp_coll_req_free(req->handle);
     if (req->coll_type != XCCL_BARRIER) {
-        if (ctx->rcache == NULL) {
+        if (req->sharp_buf != NULL){
+            req->sharp_buf->used = 0;
+        }
+        else if (ctx->rcache != NULL) {
+            xccl_sharp_mem_rcache_dereg(ctx, req->src_rregion);
+            xccl_sharp_mem_rcache_dereg(ctx, req->dst_rregion);
+
+        } else {
             rc = sharp_coll_dereg_mr(ctx->sharp_context,
                                      req->reduce_spec.sbuf_desc.buffer.mem_handle);
             if (rc != SHARP_COLL_SUCCESS) {
@@ -207,9 +270,6 @@ xccl_status_t xccl_sharp_collective_finalize(xccl_coll_req_h request)
             if (rc != SHARP_COLL_SUCCESS) {
                 xccl_sharp_error("SHARP deregmr failed\n");
             }
-        } else {
-            xccl_sharp_mem_rcache_dereg(ctx, req->src_rregion);
-            xccl_sharp_mem_rcache_dereg(ctx, req->dst_rregion);
         }
     }
     free(request);

--- a/src/team_lib/sharp/xccl_sharp_collective.c
+++ b/src/team_lib/sharp/xccl_sharp_collective.c
@@ -62,7 +62,7 @@ xccl_sharp_allreduce_init(xccl_coll_op_args_t* coll_args,
     req->super.lib  = &xccl_team_lib_sharp.super;
     req->team       = team_sharp;
     
-    if (team_sharp_ctx == NULL) {
+    if (team_sharp_ctx->rcache == NULL) {
         rc = sharp_coll_reg_mr(team_sharp_ctx->sharp_context,
                                coll_args->buffer_info.src_buffer,
                                coll_args->buffer_info.len, &src_mr);

--- a/src/team_lib/sharp/xccl_sharp_collective.c
+++ b/src/team_lib/sharp/xccl_sharp_collective.c
@@ -79,13 +79,13 @@ xccl_sharp_allreduce_init(xccl_coll_op_args_t* coll_args,
                                coll_args->buffer_info.src_buffer,
                                coll_args->buffer_info.len, &send_mr);
         if (rc != SHARP_COLL_SUCCESS) {
-            fprintf(stderr, "SHARP regmr failed\n");
+            xccl_sharp_error("SHARP regmr failed\n");
         }
         rc = sharp_coll_reg_mr(team_sharp_ctx->sharp_context,
                                coll_args->buffer_info.dst_buffer,
                                coll_args->buffer_info.len, &recv_mr);
         if (rc != SHARP_COLL_SUCCESS) {
-            fprintf(stderr, "SHARP regmr failed\n");
+            xccl_sharp_error("SHARP regmr failed\n");
         }
         req->reduce_spec.sbuf_desc.buffer.ptr        = coll_args->buffer_info.src_buffer;
         req->reduce_spec.sbuf_desc.buffer.mem_handle = send_mr;
@@ -198,13 +198,13 @@ xccl_status_t xccl_sharp_collective_finalize(xccl_coll_req_h request)
             rc = sharp_coll_dereg_mr(ctx->sharp_context,
                                     req->reduce_spec.sbuf_desc.buffer.mem_handle);
             if (rc != SHARP_COLL_SUCCESS) {
-                fprintf(stderr, "SHARP deregmr failed\n");
+                xccl_sharp_error("SHARP deregmr failed\n");
             }
 
             rc = sharp_coll_dereg_mr(ctx->sharp_context,
                                     req->reduce_spec.rbuf_desc.buffer.mem_handle);
             if (rc != SHARP_COLL_SUCCESS) {
-                fprintf(stderr, "SHARP deregmr failed\n");
+                xccl_sharp_error("SHARP deregmr failed\n");
             }
 
         } else {

--- a/src/team_lib/sharp/xccl_sharp_collective.h
+++ b/src/team_lib/sharp/xccl_sharp_collective.h
@@ -14,6 +14,7 @@ typedef struct xccl_sharp_coll_req {
     struct sharp_coll_reduce_spec  reduce_spec;
     struct sharp_coll_comm         *sharp_comm;
     void                           *handle;
+    xccl_sharp_buf_t               *sharp_buf;
     xccl_collective_type_t         coll_type;
     int                            (*start)(struct xccl_sharp_coll_req* req);
     xccl_sharp_rcache_region_t     *src_rregion;

--- a/src/team_lib/sharp/xccl_sharp_collective.h
+++ b/src/team_lib/sharp/xccl_sharp_collective.h
@@ -5,23 +5,27 @@
 
 #ifndef XCCL_TEAM_SHARP_COLLECTIVE_H_
 #define XCCL_TEAM_SHARP_COLLECTIVE_H_
+
 #include "xccl_sharp_lib.h"
 
 typedef struct xccl_sharp_coll_req {
-    xccl_coll_req_t                 super;
+    xccl_coll_req_t                super;
     xccl_sharp_team_t              *team;
-    struct sharp_coll_reduce_spec   reduce_spec;
+    struct sharp_coll_reduce_spec  reduce_spec;
     struct sharp_coll_comm         *sharp_comm;
     void                           *handle;
-    xccl_sharp_buf_t               *sharp_buf;
-    xccl_collective_type_t          coll_type;
+    xccl_collective_type_t         coll_type;
     int                            (*start)(struct xccl_sharp_coll_req* req);
+    xccl_sharp_rcache_region_t     *src_rregion;
+    xccl_sharp_rcache_region_t     *dst_rregion;
 } xccl_sharp_coll_req_t;
 
-xccl_status_t xccl_sharp_collective_init(xccl_coll_op_args_t *coll_args, xccl_coll_req_h *request,
+xccl_status_t xccl_sharp_collective_init(xccl_coll_op_args_t *coll_args,
+                                         xccl_coll_req_h *request,
                                          xccl_tl_team_t *team);
 xccl_status_t xccl_sharp_collective_post(xccl_coll_req_h request);
 xccl_status_t xccl_sharp_collective_wait(xccl_coll_req_h request);
 xccl_status_t xccl_sharp_collective_test(xccl_coll_req_h request);
 xccl_status_t xccl_sharp_collective_finalize(xccl_coll_req_h request);
+
 #endif

--- a/src/team_lib/sharp/xccl_sharp_lib.c
+++ b/src/team_lib/sharp/xccl_sharp_lib.c
@@ -132,9 +132,9 @@ xccl_sharp_create_context(xccl_team_lib_h lib, xccl_context_config_h config,
     int ret = sharp_coll_init(&init_spec, &ctx->sharp_context);
     if (ret < 0 ) {
         if (config->oob.rank == 0) {
-            fprintf(stderr, "Failed to initialize SHARP collectives:%s(%d)"
-                            "job ID:%" PRIu64"\n",
-                            sharp_coll_strerror(ret), ret, init_spec.job_id);
+            xccl_sharp_error("Failed to initialize SHARP collectives:%s(%d)"
+                             "job ID:%" PRIu64"\n",
+                             sharp_coll_strerror(ret), ret, init_spec.job_id);
         }
         free(ctx);
         return XCCL_ERR_NO_MESSAGE;
@@ -176,8 +176,8 @@ xccl_sharp_team_create_post(xccl_tl_context_t *context,
                                &team_sharp->sharp_comm);
     if (ret<0) {
         if (oob.rank == 0) {
-            fprintf(stderr, "SHARP group create failed:%s(%d)",
-                    sharp_coll_strerror(ret), ret);
+            xccl_sharp_error("SHARP group create failed:%s(%d)",
+                              sharp_coll_strerror(ret), ret);
         }
         free(team_sharp);
         return XCCL_ERR_NO_MESSAGE;
@@ -189,7 +189,7 @@ xccl_sharp_team_create_post(xccl_tl_context_t *context,
                                2*XCCL_SHARP_REG_BUF_SIZE,
                                &team_sharp->bufs[i].mr);
         if (ret != SHARP_COLL_SUCCESS) {
-            fprintf(stderr, "SHARP regmr failed\n");
+            xccl_sharp_error("SHARP regmr failed\n");
         }
         team_sharp->bufs[i].used = 0;
     }
@@ -215,7 +215,7 @@ static xccl_status_t xccl_sharp_team_destroy(xccl_tl_team_t *team)
         rc = sharp_coll_dereg_mr(team_sharp_ctx->sharp_context,
                                  team_sharp->bufs[i].mr);
         if (rc != SHARP_COLL_SUCCESS) {
-            fprintf(stderr, "SHARP deregmr failed\n");
+            xccl_sharp_error("SHARP deregmr failed\n");
         }
         free(team_sharp->bufs[i].buf);
     }

--- a/src/team_lib/sharp/xccl_sharp_lib.c
+++ b/src/team_lib/sharp/xccl_sharp_lib.c
@@ -2,6 +2,9 @@
  * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
+
+#include "config.h"
+
 #include "xccl_sharp_lib.h"
 #include "xccl_sharp_collective.h"
 #include "xccl_sharp_map.h"

--- a/src/team_lib/sharp/xccl_sharp_lib.h
+++ b/src/team_lib/sharp/xccl_sharp_lib.h
@@ -21,6 +21,7 @@ typedef struct xccl_team_lib_sharp {
 
 typedef struct xccl_team_lib_sharp_config {
     xccl_team_lib_config_t super;
+    int                    enable_rcache;
 } xccl_team_lib_sharp_config_t;
 
 extern xccl_team_lib_sharp_t xccl_team_lib_sharp;

--- a/src/team_lib/sharp/xccl_sharp_lib.h
+++ b/src/team_lib/sharp/xccl_sharp_lib.h
@@ -52,9 +52,18 @@ typedef struct xccl_sharp_context {
     ucs_rcache_t              *rcache;
 } xccl_sharp_context_t;
 
+typedef struct xccl_sharp_buf {
+    void  *buf;
+    void  *mr;
+    void  *orig_src_buf;
+    void  *orig_dst_buf;
+    int   used;
+} xccl_sharp_buf_t;
+
 typedef struct xccl_sharp_team {
     xccl_tl_team_t         super;
     struct sharp_coll_comm *sharp_comm;
+    xccl_sharp_buf_t       *bufs;
 } xccl_sharp_team_t;
 
 #endif

--- a/src/team_lib/sharp/xccl_sharp_lib.h
+++ b/src/team_lib/sharp/xccl_sharp_lib.h
@@ -12,9 +12,31 @@
 #define XCCL_SHARP_REG_BUF_NUM  10
 
 typedef struct xccl_team_lib_sharp {
-    xccl_team_lib_t super;
+    xccl_team_lib_t            super;
+    ucs_log_component_config_t log_component;
 } xccl_team_lib_sharp_t;
+
+typedef struct xccl_team_lib_sharp_config {
+    xccl_team_lib_config_t super;
+} xccl_team_lib_sharp_config_t;
+
 extern xccl_team_lib_sharp_t xccl_team_lib_sharp;
+
+#define xccl_team_sharp_log_component(_level, _fmt, ...) \
+    do { \
+        ucs_log_component(_level, &xccl_team_lib_sharp.log_component, _fmt, ## __VA_ARGS__); \
+    } while (0)
+
+#define xccl_sharp_error(_fmt, ...)        xccl_team_sharp_log_component(UCS_LOG_LEVEL_ERROR, _fmt, ## __VA_ARGS__)
+#define xccl_sharp_warn(_fmt, ...)         xccl_team_sharp_log_component(UCS_LOG_LEVEL_WARN, _fmt,  ## __VA_ARGS__)
+#define xccl_sharp_info(_fmt, ...)         xccl_team_sharp_log_component(UCS_LOG_LEVEL_INFO, _fmt, ## __VA_ARGS__)
+#define xccl_sharp_debug(_fmt, ...)        xccl_team_sharp_log_component(UCS_LOG_LEVEL_DEBUG, _fmt, ##  __VA_ARGS__)
+#define xccl_sharp_trace(_fmt, ...)        xccl_team_sharp_log_component(UCS_LOG_LEVEL_TRACE, _fmt, ## __VA_ARGS__)
+#define xccl_sharp_trace_req(_fmt, ...)    xccl_team_sharp_log_component(UCS_LOG_LEVEL_TRACE_REQ, _fmt, ## __VA_ARGS__)
+#define xccl_sharp_trace_data(_fmt, ...)   xccl_team_sharp_log_component(UCS_LOG_LEVEL_TRACE_DATA, _fmt, ## __VA_ARGS__)
+#define xccl_sharp_trace_async(_fmt, ...)  xccl_team_sharp_log_component(UCS_LOG_LEVEL_TRACE_ASYNC, _fmt, ## __VA_ARGS__)
+#define xccl_sharp_trace_func(_fmt, ...)   xccl_team_sharp_log_component(UCS_LOG_LEVEL_TRACE_FUNC, "%s(" _fmt ")", __FUNCTION__, ## __VA_ARGS__)
+#define xccl_sharp_trace_poll(_fmt, ...)   xccl_team_sharp_log_component(UCS_LOG_LEVEL_TRACE_POLL, _fmt, ## __VA_ARGS__)
 
 typedef struct xccl_sharp_context {
     xccl_tl_context_t             super;

--- a/src/team_lib/sharp/xccl_sharp_lib.h
+++ b/src/team_lib/sharp/xccl_sharp_lib.h
@@ -11,24 +11,23 @@
 #include <ucs/memory/rcache.h>
 #include "xccl_team_lib.h"
 
-#define XCCL_SHARP_REG_BUF_SIZE 1024
-#define XCCL_SHARP_REG_BUF_NUM  10
-
-typedef struct xccl_team_lib_sharp {
-    xccl_team_lib_t            super;
-    ucs_log_component_config_t log_component;
-} xccl_team_lib_sharp_t;
-
 typedef struct xccl_team_lib_sharp_config {
     xccl_team_lib_config_t super;
     int                    enable_rcache;
+    size_t                 zcopy_thresh;
+    unsigned               bcopy_buf_num;
 } xccl_team_lib_sharp_config_t;
+
+typedef struct xccl_team_lib_sharp {
+    xccl_team_lib_t              super;
+    xccl_team_lib_sharp_config_t config;
+} xccl_team_lib_sharp_t;
 
 extern xccl_team_lib_sharp_t xccl_team_lib_sharp;
 
 #define xccl_team_sharp_log_component(_level, _fmt, ...) \
     do { \
-        ucs_log_component(_level, &xccl_team_lib_sharp.log_component, _fmt, ## __VA_ARGS__); \
+        ucs_log_component(_level, &xccl_team_lib_sharp.config.super.log_component, _fmt, ## __VA_ARGS__); \
     } while (0)
 
 #define xccl_sharp_error(_fmt, ...)        xccl_team_sharp_log_component(UCS_LOG_LEVEL_ERROR, _fmt, ## __VA_ARGS__)

--- a/src/team_lib/sharp/xccl_sharp_lib.h
+++ b/src/team_lib/sharp/xccl_sharp_lib.h
@@ -2,10 +2,13 @@
  * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
+
 #ifndef XCCL_TEAM_LIB_SHARP_H_
 #define XCCL_TEAM_LIB_SHARP_H_
+
 #include <sharp/api/version.h>
 #include <sharp/api/sharp_coll.h>
+#include <ucs/memory/rcache.h>
 #include "xccl_team_lib.h"
 
 #define XCCL_SHARP_REG_BUF_SIZE 1024
@@ -38,22 +41,20 @@ extern xccl_team_lib_sharp_t xccl_team_lib_sharp;
 #define xccl_sharp_trace_func(_fmt, ...)   xccl_team_sharp_log_component(UCS_LOG_LEVEL_TRACE_FUNC, "%s(" _fmt ")", __FUNCTION__, ## __VA_ARGS__)
 #define xccl_sharp_trace_poll(_fmt, ...)   xccl_team_sharp_log_component(UCS_LOG_LEVEL_TRACE_POLL, _fmt, ## __VA_ARGS__)
 
+typedef struct xccl_sharp_rcache_region {
+    ucs_rcache_region_t super;
+    void                *memh;
+} xccl_sharp_rcache_region_t;
+
 typedef struct xccl_sharp_context {
-    xccl_tl_context_t             super;
+    xccl_tl_context_t         super;
     struct sharp_coll_context *sharp_context;
+    ucs_rcache_t              *rcache;
 } xccl_sharp_context_t;
 
-typedef struct xccl_sharp_buf {
-    void *buf;
-    void *mr;
-    void *orig_src_buf;
-    void *orig_dst_buf;
-    int   used;
-} xccl_sharp_buf_t;
-
 typedef struct xccl_sharp_team {
-    xccl_tl_team_t          super;
+    xccl_tl_team_t         super;
     struct sharp_coll_comm *sharp_comm;
-    xccl_sharp_buf_t        bufs[XCCL_SHARP_REG_BUF_NUM];
 } xccl_sharp_team_t;
+
 #endif


### PR DESCRIPTION
TEAM SHARP:
1. Added environment config
2. Added registration cache. XCCL_TEAM_SHARP_RCACHE can be used to control registration cache 
3. Removed LL buffers
