### PR TITLE
workaround the libtool build with hpcx module issue

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,3 +50,7 @@ libxccl_la_SOURCES =       \
 	utils/mem_component.c
 
 libxccl_ladir = $(includedir)
+
+install-exec-hook:
+	cp -f $(XCCL_TOP_BUILDDIR)/src/libxccl.la $(libdir)/
+	perl -pi -e "s/installed=no/installed=yes/" $(libdir)/libxccl.la


### PR DESCRIPTION
    The libxccl.la file gets wrong ucs dependency when installed but
    the .la in buildir/src is correct. Use it.