### PR TITLE
Hier team node leader

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,12 @@ jobs:
         export LD_LIBRARY_PATH=/tmp/ucx/install/lib:$LD_LIBRARY_PATH
         mpirun --oversubscribe -x XCCL_TEST_TLS=hier -np 8 -H localhost:8 --bind-to none -mca coll ^hcoll ./test/test_mpi_allreduce
         mpirun --oversubscribe -x XCCL_TEST_TLS=hier -np 8 -H localhost:8 --bind-to none -mca coll ^hcoll ./test/test_mpi_bcast
-        mpirun --oversubscribe -x XCCL_TEST_TLS=hier -np 8 -H localhost:8 --bind-to none -mca coll ^hcoll ./test/test_mpi_barrier        
+        mpirun --oversubscribe -x XCCL_TEST_TLS=hier -np 8 -H localhost:8 --bind-to none -mca coll ^hcoll ./test/test_mpi_barrier
+
+        mpirun --oversubscribe -x XCCL_TEAM_HIER_NODE_LEADER_RANK_ID=3 -x XCCL_TEST_TLS=hier -np 8 -H localhost:8 --bind-to none -mca coll ^hcoll ./test/test_mpi_allreduce
+        mpirun --oversubscribe -x XCCL_TEAM_HIER_NODE_LEADER_RANK_ID=4 -x XCCL_TEST_TLS=hier -np 8 -H localhost:8 --bind-to none -mca coll ^hcoll ./test/test_mpi_bcast
+        mpirun --oversubscribe -x XCCL_TEAM_HIER_NODE_LEADER_RANK_ID=5 -x XCCL_TEST_TLS=hier -np 8 -H localhost:8 --bind-to none -mca coll ^hcoll ./test/test_mpi_barrier
+
         mpirun --oversubscribe -x XCCL_TEST_TLS=ucx -np 8 -H localhost:8 --bind-to none -mca coll ^hcoll ./test/test_mpi_allreduce
         mpirun --oversubscribe -x XCCL_TEST_TLS=ucx -np 8 -H localhost:8 --bind-to none -mca coll ^hcoll ./test/test_mpi_bcast
         mpirun --oversubscribe -x XCCL_TEST_TLS=ucx -np 8 -H localhost:8 --bind-to none -mca coll ^hcoll ./test/test_mpi_barrier        

--- a/src/core/xccl_init.c
+++ b/src/core/xccl_init.c
@@ -159,6 +159,7 @@ static void xccl_constructor(void)
     /* xccl_print_libs(&xccl_static_lib); */
     gethostname(hostname, sizeof(hostname));
     xccl_local_proc_info.node_hash = xccl_str_hash(hostname);
+    xccl_local_proc_info.pid       = getpid();
     xccl_get_bound_socket_id(&xccl_local_proc_info.socketid);
 }
 

--- a/src/core/xccl_lib.c
+++ b/src/core/xccl_lib.c
@@ -16,8 +16,8 @@ UCS_CONFIG_REGISTER_TABLE(xccl_lib_config_table, "XCCL", NULL, xccl_lib_config_t
 #define CHECK_LIB_CONFIG_CAP(_cap, _CAP_FIELD) do{                        \
         if ((params->field_mask & XCCL_LIB_PARAM_FIELD_ ## _CAP_FIELD) && \
             !(params-> _cap & tl->params. _cap)) {                        \
-            printf("Disqualifying team %s due to %s cap\n",               \
-                   tl->name, UCS_PP_QUOTE(_CAP_FIELD));                   \
+            xccl_info("Disqualifying team %s due to %s cap",              \
+                      tl->name, UCS_PP_QUOTE(_CAP_FIELD));                \
             continue;                                                     \
         }                                                                 \
     } while(0)

--- a/src/core/xccl_team_lib.h
+++ b/src/core/xccl_team_lib.h
@@ -113,6 +113,7 @@ xccl_oob_allgather(void *sbuf, void* rbuf, size_t len, xccl_oob_collectives_t *o
 typedef struct xccl_local_proc_info {
     unsigned long node_hash;
     int           socketid; //if process is bound to a socket
+    int           pid;
 } xccl_local_proc_info_t;
 
 xccl_local_proc_info_t* xccl_local_process_info();

--- a/src/team_lib/hier/xccl_hier_context.c
+++ b/src/team_lib/hier/xccl_hier_context.c
@@ -79,6 +79,7 @@ static void compute_layout(xccl_hier_context_t *ctx) {
     int min_ppn = INT_MAX;
     int max_ppn = 0;
     int nnodes = 1;
+    int max_sockid = 0;
     int i, j;
     for (i=1; i<ctx_size; i++) {
         unsigned long hash = sorted[i].node_hash;
@@ -98,6 +99,9 @@ static void compute_layout(xccl_hier_context_t *ctx) {
         }
     }
     for (j=0; j<ctx_size; j++) {
+        if (ctx->procs[j].socketid > max_sockid) {
+            max_sockid = ctx->procs[j].socketid;
+        }
         if (ctx->procs[j].node_hash == current_hash) {
             ctx->procs[j].node_id = nnodes - 1;
         }
@@ -109,6 +113,7 @@ static void compute_layout(xccl_hier_context_t *ctx) {
     ctx->nnodes = nnodes;
     ctx->min_ppn = min_ppn;
     ctx->max_ppn = max_ppn;
+    ctx->max_n_sockets = max_sockid+1;
 }
 
 xccl_status_t xccl_hier_create_context(xccl_team_lib_t *lib,

--- a/src/team_lib/hier/xccl_hier_context.h
+++ b/src/team_lib/hier/xccl_hier_context.h
@@ -28,6 +28,8 @@ typedef struct xccl_hier_context {
     int                       nnodes;
     int                       max_ppn;
     int                       min_ppn;
+    int                       max_n_sockets;
+    int                       node_leader_rank_id;
     int                       use_sm_get_bcast;
     size_t                    bcast_sm_get_thresh;
     int                       bcast_pipeline_depth;

--- a/src/team_lib/hier/xccl_hier_context.h
+++ b/src/team_lib/hier/xccl_hier_context.h
@@ -13,6 +13,7 @@ typedef struct xccl_hier_proc_data {
     unsigned long node_hash;
     int           node_id;
     int           socketid; //if process is bound to a socket
+    int           pid;
 } xccl_hier_proc_data_t;
 
 typedef struct xccl_hier_tl_t {
@@ -31,8 +32,8 @@ typedef struct xccl_hier_context {
     int                       max_n_sockets;
     int                       node_leader_rank_id;
     int                       use_sm_get_bcast;
-    size_t                    bcast_sm_get_thresh;
     int                       bcast_pipeline_depth;
+    size_t                    bcast_sm_get_thresh;
     size_t                    bcast_pipeline_thresh;
 } xccl_hier_context_t;
 

--- a/src/team_lib/hier/xccl_hier_lib.c
+++ b/src/team_lib/hier/xccl_hier_lib.c
@@ -68,7 +68,13 @@ static ucs_config_field_t xccl_tl_hier_context_config_table[] = {
      ucs_offsetof(xccl_tl_hier_context_config_t, bcast_sm_get_thresh),
      UCS_CONFIG_TYPE_MEMUNITS
      },
-    
+
+    {"NODE_LEADER_RANK_ID", "0",
+     "",
+     ucs_offsetof(xccl_tl_hier_context_config_t, node_leader_rank_id),
+     UCS_CONFIG_TYPE_UINT
+     },
+
     {NULL}
 };
 

--- a/src/team_lib/hier/xccl_hier_lib.h
+++ b/src/team_lib/hier/xccl_hier_lib.h
@@ -14,10 +14,11 @@ typedef struct xccl_tl_hier_context_config {
     int                      enable_sharp;
     int                      enable_shmseg;
     int                      enable_vmc;
-    size_t                   bcast_pipeline_thresh;
     unsigned                 bcast_pipeline_depth;
     int                      bcast_sm_get;
+    int                      node_leader_rank_id;
     size_t                   bcast_sm_get_thresh;
+    size_t                   bcast_pipeline_thresh;
 } xccl_tl_hier_context_config_t;
 
 typedef struct xccl_team_lib_hier {

--- a/src/team_lib/hier/xccl_hier_sbgp.c
+++ b/src/team_lib/hier/xccl_hier_sbgp.c
@@ -12,12 +12,18 @@
 #include "xccl_hier_team.h"
 #include "xccl_hier_context.h"
 
+#define SWAP(_x, _y) do{                        \
+        int _tmp   = (_x);                      \
+        (_x)       = (_y);                      \
+        (_y)       = _tmp;                      \
+    } while(0)
 enum {
     LOCAL_NODE,
     LOCAL_SOCKET,
 };
 
-static inline int is_rank_local(int rank, xccl_hier_team_t *team, int local) {
+static inline int is_rank_local(int rank, xccl_hier_team_t *team, int local)
+{
     switch (local) {
     case LOCAL_NODE:
         return is_rank_on_local_node(rank, team);
@@ -26,17 +32,64 @@ static inline int is_rank_local(int rank, xccl_hier_team_t *team, int local) {
     }
 }
 
-static inline xccl_status_t sbgp_create_local(sbgp_t *sbgp, int local) {
+static inline xccl_status_t sbgp_create_socket(sbgp_t *sbgp) {
     xccl_hier_team_t *team = sbgp->hier_team;
+    sbgp_t *node_sbgp      = &team->sbgps[SBGP_NODE];
     int *local_ranks;
     int group_size     = team->super.params.oob.size;
     int group_rank     = team->super.params.oob.rank;
-    int max_local_size = 256;
-    int node_rank = 0, node_size = 0, i;
-    local_ranks = (int*)malloc(max_local_size*sizeof(int));
+    int nlr            = team->node_leader_rank;
+    int sock_rank = 0, sock_size = 0, i, r, nlr_pos;
+    assert(node_sbgp->status == SBGP_ENABLED);
+    local_ranks = (int*)malloc(node_sbgp->group_size*sizeof(int));
 
+    for (i=0; i<node_sbgp->group_size; i++) {
+        r = node_sbgp->rank_map[i];
+        if (is_rank_local(r, team, LOCAL_SOCKET)) {
+            local_ranks[sock_size] = r;
+            if (r == group_rank) {
+                sock_rank = sock_size;
+            }
+            sock_size++;
+        }
+    }
+    sbgp->group_size = sock_size;
+    sbgp->group_rank = sock_rank;
+    sbgp->rank_map = local_ranks;
+    nlr_pos = -1;
+    for (i=0; i<sock_size; i++) {
+        if (nlr == local_ranks[i]) {
+            nlr_pos = i;
+            break;
+        }
+    }
+    if (nlr_pos > 0) {
+        if (sock_rank == 0) sbgp->group_rank = nlr_pos;
+        if (sock_rank == nlr_pos) sbgp->group_rank = 0;
+        SWAP(local_ranks[nlr_pos], local_ranks[0]);
+    }
+    if (sock_size > 1) {
+        sbgp->status = SBGP_ENABLED;
+    } else {
+        sbgp->status = SBGP_NOT_EXISTS;
+    }
+    return XCCL_OK;
+}
+
+static inline xccl_status_t sbgp_create_node(sbgp_t *sbgp)
+{
+    xccl_hier_team_t *team   = sbgp->hier_team;
+    xccl_hier_context_t *ctx = ucs_derived_of(team->super.ctx,
+                                               xccl_hier_context_t);
+    int group_size           = team->super.params.oob.size;
+    int group_rank           = team->super.params.oob.rank;
+    int max_local_size       = 256;
+    int ctx_nlr              = ctx->node_leader_rank_id;
+    int node_rank = 0, node_size = 0, i;
+    int *local_ranks;
+    local_ranks = (int*)malloc(max_local_size*sizeof(int));
     for (i=0; i<group_size; i++) {
-        if (is_rank_local(i, team, local)) {
+        if (is_rank_local(i, team, LOCAL_NODE)) {
             if (node_size == max_local_size) {
                 max_local_size *= 2;
                 local_ranks = (int*)realloc(local_ranks, max_local_size*sizeof(int));
@@ -52,6 +105,21 @@ static inline xccl_status_t sbgp_create_local(sbgp_t *sbgp, int local) {
     sbgp->group_size = node_size;
     sbgp->group_rank = node_rank;
     sbgp->rank_map = local_ranks;
+    if (0 < ctx_nlr && ctx_nlr < node_size)  {
+        /* Rotate local_ranks array so that node_leader_rank_id becomes first
+           in that array */
+        sbgp->rank_map = (int*)malloc(node_size*sizeof(int));
+        for (i=ctx_nlr; i<node_size; i++) {
+            sbgp->rank_map[i - ctx_nlr] = local_ranks[i];
+        }
+
+        for (i=0; i<ctx_nlr; i++) {
+            sbgp->rank_map[node_size - ctx_nlr + i] = local_ranks[i];
+        }
+        sbgp->group_rank = (node_rank + node_size - ctx_nlr) % node_size;
+        free(local_ranks);
+    }
+    team->node_leader_rank = sbgp->rank_map[0];
     if (node_size > 1) {
         sbgp->status = SBGP_ENABLED;
     } else {
@@ -60,20 +128,14 @@ static inline xccl_status_t sbgp_create_local(sbgp_t *sbgp, int local) {
     return XCCL_OK;
 }
 
-static xccl_status_t sbgp_create_node(sbgp_t *sbgp) {
-    return sbgp_create_local(sbgp, LOCAL_NODE);
-}
-
-static xccl_status_t sbgp_create_socket(sbgp_t *sbgp) {
-    return sbgp_create_local(sbgp, LOCAL_SOCKET);
-}
-
-static xccl_status_t sbgp_create_node_leaders(sbgp_t *sbgp) {
+static xccl_status_t sbgp_create_node_leaders(sbgp_t *sbgp)
+{
     xccl_hier_team_t *team = sbgp->hier_team;
     xccl_hier_context_t *ctx = ucs_derived_of(team->super.ctx,
                                                xccl_hier_context_t);
     int comm_size     = team->super.params.oob.size;
     int comm_rank     = team->super.params.oob.rank;
+    int ctx_nlr       = ctx->node_leader_rank_id;
     int i, c;
     int i_am_node_leader = 0;
     int nnodes = ctx->nnodes;
@@ -82,17 +144,18 @@ static xccl_status_t sbgp_create_node_leaders(sbgp_t *sbgp) {
     int n_node_leaders;
 
     for (i=0; i<nnodes; i++) {
-        nl_array_1[i] = INT_MAX;
+        nl_array_1[i] = 0;
         nl_array_2[i] = INT_MAX;
     }
 
     for (i=0; i<comm_size; i++) {
         int ctx_rank = xccl_hier_team_rank2ctx(team, i);
         int node_id = ctx->procs[ctx_rank].node_id;
-        if (nl_array_1[node_id] > ctx_rank) {
-            nl_array_1[node_id] = ctx_rank;
+        if (nl_array_1[node_id] == 0 ||
+            nl_array_1[node_id] == ctx_nlr) {
             nl_array_2[node_id] = i;
         }
+        nl_array_1[node_id]++;
     }
     n_node_leaders = 0;
     for (i=0; i<nnodes; i++) {
@@ -122,59 +185,77 @@ static xccl_status_t sbgp_create_node_leaders(sbgp_t *sbgp) {
     return XCCL_OK;
 }
 
-static xccl_status_t sbgp_create_socket_leaders(sbgp_t *sbgp) {
+static xccl_status_t sbgp_create_socket_leaders(sbgp_t *sbgp)
+{
     xccl_hier_team_t *team = sbgp->hier_team;
     xccl_hier_context_t *ctx = ucs_derived_of(team->super.ctx,
                                                xccl_hier_context_t);
+    sbgp_t *node_sbgp      = &team->sbgps[SBGP_NODE];
     int comm_size     = team->super.params.oob.size;
     int comm_rank     = team->super.params.oob.rank;
-    int i, c;
-    int i_am_socket_leader = 0;
-    int max_ppn = ctx->max_ppn;//TODO can be changed to max_sockets_per_node
-    int *sl_array_1 = (int*)malloc(max_ppn*sizeof(int));
-    int *sl_array_2 = (int*)malloc(max_ppn*sizeof(int));
-    int n_socket_leaders;
-    unsigned long my_node_hash = ctx->local_proc.node_hash;
-    for (i=0; i<max_ppn; i++) {
-        sl_array_1[i] = INT_MAX;
-        sl_array_2[i] = INT_MAX;
-    }
+    int nlr            = team->node_leader_rank;
+    int i_am_socket_leader = (nlr == comm_rank);
+    int max_n_sockets = ctx->max_n_sockets;
+    int *sl_array = (int*)malloc(max_n_sockets*sizeof(int));
+    int n_socket_leaders = 1, i, nlr_sock_id;
 
-     for (i=0; i<comm_size; i++) {
-        int ctx_rank = xccl_hier_team_rank2ctx(team, i);
+    for (i=0; i<max_n_sockets; i++) {
+        sl_array[i] = INT_MAX;
+    }
+    nlr_sock_id = ctx->procs[xccl_hier_team_rank2ctx(team, nlr)].socketid;
+    sl_array[nlr_sock_id] = nlr;
+
+    for (i=0; i<node_sbgp->group_size; i++) {
+        int r = node_sbgp->rank_map[i];
+        int ctx_rank = xccl_hier_team_rank2ctx(team, r);
         int socket_id = ctx->procs[ctx_rank].socketid;
-        unsigned long node_hash = ctx->procs[ctx_rank].node_hash;
-        if (node_hash == my_node_hash &&
-            sl_array_1[socket_id] > ctx_rank) {
-            sl_array_1[socket_id] = ctx_rank;
-            sl_array_2[socket_id] = i;
-        }
-    }
-    n_socket_leaders = 0;
-    for (i=0; i<max_ppn; i++) {
-        if (sl_array_2[i] != INT_MAX) {
-            if (comm_rank == sl_array_2[i]) {
+        if (sl_array[socket_id] == INT_MAX) {
+            n_socket_leaders++;
+            sl_array[socket_id] = r;
+            if (r == comm_rank) {
                 i_am_socket_leader = 1;
-                sbgp->group_rank = n_socket_leaders;
             }
-            sl_array_1[n_socket_leaders++] = sl_array_2[i];
         }
     }
-    free(sl_array_2);
 
     if (n_socket_leaders > 1) {
         if (i_am_socket_leader) {
+            int sl_rank;
+            sbgp->rank_map = (int*)malloc(sizeof(int)*n_socket_leaders);
+            n_socket_leaders = 0;
+            for (i=0; i<max_n_sockets; i++) {
+                if (sl_array[i] != INT_MAX) {
+                    sbgp->rank_map[n_socket_leaders] = sl_array[i];
+                    if (comm_rank == sl_array[i]) {
+                        sl_rank = n_socket_leaders;
+                    }
+                    n_socket_leaders++;
+                }
+            }
+            int nlr_pos = -1;
+            for (i=0; i<n_socket_leaders; i++) {
+                if (sbgp->rank_map[i] == nlr) {
+                    nlr_pos = i;
+                    break;
+                }
+            }
+            assert(nlr_pos >= 0);
+            sbgp->group_rank = sl_rank;
+            if (nlr_pos > 0) {
+                if (sl_rank == 0) sbgp->group_rank = nlr_pos;
+                if (sl_rank == nlr_pos) sbgp->group_rank = 0;
+                SWAP(sbgp->rank_map[nlr_pos], sbgp->rank_map[0]);
+            }
+
             sbgp->group_size = n_socket_leaders;
-            sbgp->rank_map = sl_array_1;
             sbgp->status = SBGP_ENABLED;
         } else {
-            free(sl_array_1);
             sbgp->status = SBGP_DISABLED;
         }
     } else {
-        free(sl_array_1);
         sbgp->status = SBGP_NOT_EXISTS;
     }
+    free(sl_array);
     return XCCL_OK;
 }
 
@@ -184,8 +265,8 @@ char* sbgp_type_str[SBGP_LAST] = {"undef", "numa", "socket", "node", "node_leade
 static void print_sbgp(sbgp_t *sbgp) {
     int i;
     if (sbgp->group_rank == 0 && sbgp->status == SBGP_ENABLED) {
-        printf("sbgp \"%s\": group_size %d, xccl_ranks=[", sbgp_type_str[sbgp->type],
-               sbgp->group_size);
+        printf("sbgp: %15s: group_size %4d, xccl_ranks=[ ",
+               sbgp_type_str[sbgp->type], sbgp->group_size);
         for (i=0; i<sbgp->group_size; i++) {
             printf("%d ", sbgp->rank_map[i]);
         }
@@ -199,15 +280,22 @@ xccl_status_t sbgp_create(xccl_hier_team_t *team, sbgp_type_t type) {
     sbgp_t *sbgp = &team->sbgps[type];
     sbgp->hier_team = team;
     sbgp->type = type;
+    sbgp->status= SBGP_NOT_EXISTS;
     switch(type) {
     case SBGP_NODE:
         status = sbgp_create_node(sbgp);
         break;
     case SBGP_SOCKET:
-        status = sbgp_create_socket(sbgp);
+        assert(SBGP_DISABLED != team->sbgps[SBGP_NODE].status);
+        if (team->sbgps[SBGP_NODE].status == SBGP_ENABLED) {
+            status = sbgp_create_socket(sbgp);
+        }
         break;
     case SBGP_NODE_LEADERS:
-        status = sbgp_create_node_leaders(sbgp);
+        assert(SBGP_DISABLED != team->sbgps[SBGP_NODE].status);
+        if (team->sbgps[SBGP_NODE].status == SBGP_ENABLED) {
+            status = sbgp_create_node_leaders(sbgp);
+        }
         break;
     case SBGP_SOCKET_LEADERS:
         status = sbgp_create_socket_leaders(sbgp);
@@ -223,9 +311,23 @@ xccl_status_t sbgp_create(xccl_hier_team_t *team, sbgp_type_t type) {
     return status;
 }
 
-xccl_status_t sbgp_cleanup(sbgp_t *sbgp) {
+xccl_status_t sbgp_cleanup(sbgp_t *sbgp)
+{
     if (sbgp->rank_map) {
         free(sbgp->rank_map);
     }
     return XCCL_OK;
+}
+
+int xccl_hier_compare_proc_data(const void* a, const void* b)
+{
+    const xccl_hier_proc_data_t *d1 = (const xccl_hier_proc_data_t*)a;
+    const xccl_hier_proc_data_t *d2 = (const xccl_hier_proc_data_t*)b;
+    if (d1->node_hash != d2->node_hash) {
+        return d1->node_hash > d2->node_hash ? 1 : -1;
+    } else if (d1->socketid != d2->socketid) {
+        return d1->socketid - d2->socketid;
+    } else {
+        return d1->pid - d2->pid;
+    }
 }

--- a/src/team_lib/hier/xccl_hier_sbgp.h
+++ b/src/team_lib/hier/xccl_hier_sbgp.h
@@ -42,4 +42,6 @@ static inline int sbgp_rank2team(sbgp_t *sbgp, int rank)
 {
     return sbgp->rank_map[rank];
 }
+
+int xccl_hier_compare_proc_data(const void* a, const void* b);
 #endif

--- a/src/team_lib/hier/xccl_hier_team.c
+++ b/src/team_lib/hier/xccl_hier_team.c
@@ -92,6 +92,8 @@ xccl_status_t xccl_hier_team_create_post(xccl_tl_context_t *context,
         hier_team->sbgps[i].status = SBGP_DISABLED;
     }
 
+    /* SBGP_NODE has to be always created first, it is used to
+       create other sbgps: socket and socket_leaders */
     sbgp_create(hier_team, SBGP_NODE);
     sbgp_create(hier_team, SBGP_SOCKET);
     sbgp_create(hier_team, SBGP_NODE_LEADERS);
@@ -103,7 +105,7 @@ xccl_status_t xccl_hier_team_create_post(xccl_tl_context_t *context,
                           XCCL_TL_UCX, XCCL_HIER_PAIR_SOCKET_LEADERS_UCX);
     xccl_hier_create_pair(&hier_team->sbgps[SBGP_NODE_LEADERS], hier_team,
                           XCCL_TL_UCX, XCCL_HIER_PAIR_NODE_LEADERS_UCX);
-
+    
     if (ctx->tls[ucs_ilog2(XCCL_TL_SHMSEG)].enabled) {
         xccl_hier_create_pair(&hier_team->sbgps[SBGP_SOCKET], hier_team,
                               XCCL_TL_SHMSEG, XCCL_HIER_PAIR_SOCKET_SHMSEG);

--- a/src/team_lib/hier/xccl_hier_team.h
+++ b/src/team_lib/hier/xccl_hier_team.h
@@ -13,9 +13,6 @@ typedef struct xccl_hier_pair {
     sbgp_t     *sbgp;
 } xccl_hier_pair_t;
 
-void xccl_hier_team_rank_data_free(xccl_hier_team_t *team);
-xccl_status_t xccl_hier_team_rank_data_init(xccl_hier_team_t *team);
-
 typedef enum {
     XCCL_HIER_PAIR_NODE_UCX,
     XCCL_HIER_PAIR_SOCKET_UCX,
@@ -28,11 +25,6 @@ typedef enum {
     XCCL_HIER_PAIR_NODE_LEADERS_VMC,
     XCCL_HIER_PAIR_LAST,
 } xccl_hier_pair_type_t;
-
-typedef struct xccl_hier_team_rank_data {
-    xccl_hier_proc_data_t pd;
-    int                   comm_rank;
-}xccl_hier_team_rank_data_t;
 
 typedef struct xccl_hier_team {
     xccl_tl_team_t             super;

--- a/src/team_lib/hier/xccl_hier_team.h
+++ b/src/team_lib/hier/xccl_hier_team.h
@@ -13,6 +13,9 @@ typedef struct xccl_hier_pair {
     sbgp_t     *sbgp;
 } xccl_hier_pair_t;
 
+void xccl_hier_team_rank_data_free(xccl_hier_team_t *team);
+xccl_status_t xccl_hier_team_rank_data_init(xccl_hier_team_t *team);
+
 typedef enum {
     XCCL_HIER_PAIR_NODE_UCX,
     XCCL_HIER_PAIR_SOCKET_UCX,
@@ -26,10 +29,16 @@ typedef enum {
     XCCL_HIER_PAIR_LAST,
 } xccl_hier_pair_type_t;
 
+typedef struct xccl_hier_team_rank_data {
+    xccl_hier_proc_data_t pd;
+    int                   comm_rank;
+}xccl_hier_team_rank_data_t;
+
 typedef struct xccl_hier_team {
-    xccl_tl_team_t     super;
-    sbgp_t             sbgps[SBGP_LAST];
-    xccl_hier_pair_t  *pairs[XCCL_HIER_PAIR_LAST];
+    xccl_tl_team_t             super;
+    sbgp_t                     sbgps[SBGP_LAST];
+    xccl_hier_pair_t           *pairs[XCCL_HIER_PAIR_LAST];
+    int                        node_leader_rank;
 } xccl_hier_team_t;
 
 xccl_status_t xccl_hier_team_create_post(xccl_tl_context_t *context,

--- a/src/team_lib/ucx/bcast/bcast_knomial.c
+++ b/src/team_lib/ucx/bcast/bcast_knomial.c
@@ -79,8 +79,8 @@ xccl_status_t xccl_ucx_bcast_knomial_start(xccl_ucx_collreq_t *req)
     size_t data_size = req->args.buffer_info.len;
     int group_rank   = req->team->params.oob.rank;
     int group_size   = req->team->params.oob.size;
-
-    xccl_ucx_trace("knomial bcast start");
+    xccl_ucx_debug("knomial bcast start: group_size %d, group_rank %d, data_size %zd",
+                   group_size, group_rank, data_size);
     memset(req->bcast_kn.reqs, 0, sizeof(req->bcast_kn.reqs));
     req->bcast_kn.radix   = 4;//TODO
     if (req->bcast_kn.radix > req->team->params.oob.size) {


### PR DESCRIPTION
Functionality allows specifying which local_node_rank will serve as "node_leader_rank" in the hierarchical team. The value is specified with: XCCL_TEAM_HIER_NODE_LEADER_RANK_ID=<value>.
If the communicator does not have that many ranks on one of the nodes (which the communicator spans) then node_leader_rank value is ignored and 0 is used.