### PR TITLE
Team ucx reduce switch to multi

### DIFF
--- a/src/team_lib/ucx/allreduce/allreduce_knomial.c
+++ b/src/team_lib/ucx/allreduce/allreduce_knomial.c
@@ -204,7 +204,7 @@ xccl_status_t xccl_ucx_allreduce_knomial_start(xccl_ucx_collreq_t *req)
 {
     size_t data_size     = req->args.buffer_info.len;
 
-    req->allreduce.radix = 4; //TODO
+    req->allreduce.radix = TEAM_UCX_CTX_REQ(req)->allreduce_kn_radix;
     if (req->allreduce.radix > req->team->params.oob.size) {
         req->allreduce.radix = req->team->params.oob.size;
     }

--- a/src/team_lib/ucx/barrier/barrier_knomial.c
+++ b/src/team_lib/ucx/barrier/barrier_knomial.c
@@ -167,7 +167,7 @@ completion:
 xccl_status_t xccl_ucx_barrier_knomial_start(xccl_ucx_collreq_t *req)
 {
     size_t data_size     = req->args.buffer_info.len;
-    req->barrier.radix = 4; //TODO
+    req->barrier.radix   = TEAM_UCX_CTX_REQ(req)->barrier_kn_radix;
     if (req->barrier.radix > req->team->params.oob.size) {
         req->barrier.radix = req->team->params.oob.size;
     }

--- a/src/team_lib/ucx/bcast/bcast_knomial.c
+++ b/src/team_lib/ucx/bcast/bcast_knomial.c
@@ -82,7 +82,7 @@ xccl_status_t xccl_ucx_bcast_knomial_start(xccl_ucx_collreq_t *req)
     xccl_ucx_debug("knomial bcast start: group_size %d, group_rank %d, data_size %zd",
                    group_size, group_rank, data_size);
     memset(req->bcast_kn.reqs, 0, sizeof(req->bcast_kn.reqs));
-    req->bcast_kn.radix   = 4;//TODO
+    req->bcast_kn.radix   = TEAM_UCX_CTX_REQ(req)->bcast_kn_radix;
     if (req->bcast_kn.radix > req->team->params.oob.size) {
         req->bcast_kn.radix = req->team->params.oob.size;
     }

--- a/src/team_lib/ucx/reduce/reduce_knomial.c
+++ b/src/team_lib/ucx/reduce/reduce_knomial.c
@@ -122,7 +122,7 @@ xccl_status_t xccl_ucx_reduce_knomial_start(xccl_ucx_collreq_t *req)
 
     xccl_ucx_trace("knomial reduce start");
     memset(req->reduce_kn.reqs, 0, sizeof(req->reduce_kn.reqs));
-    req->reduce_kn.radix   = 4;//TODO
+    req->reduce_kn.radix   = TEAM_UCX_CTX_REQ(req)->reduce_kn_radix;
     if (req->reduce_kn.radix > group_size) {
         req->reduce_kn.radix = group_size;
     }

--- a/src/team_lib/ucx/reduce/reduce_knomial.c
+++ b/src/team_lib/ucx/reduce/reduce_knomial.c
@@ -17,13 +17,14 @@
 
 xccl_status_t xccl_ucx_reduce_knomial_progress(xccl_ucx_collreq_t *req)
 {
-    xccl_ucx_request_t **reqs  = req->reduce_kn.reqs;
-    xccl_ucx_team_t *team      = ucs_derived_of(req->team, xccl_ucx_team_t);
-    size_t         data_size   = req->args.buffer_info.len;
-    int            group_rank  = team->super.params.oob.rank;
-    int            group_size  = team->super.params.oob.size;
-    int            root        = req->args.root;
-    int            radix       = req->reduce_kn.radix;
+    xccl_ucx_request_t **reqs     = req->reduce_kn.reqs;
+    xccl_ucx_team_t    *team      = ucs_derived_of(req->team, xccl_ucx_team_t);
+    size_t             data_size  = req->args.buffer_info.len;
+    int                group_rank = team->super.params.oob.rank;
+    int                group_size = team->super.params.oob.size;
+    int                root       = req->args.root;
+    int                radix      = req->reduce_kn.radix;
+    int                max_polls  = TEAM_UCX_CTX(team)->num_to_probe;
     int vrank = (group_rank - root + group_size) % group_size;
     int dist  = req->reduce_kn.dist;
     void *dst_buffer, *src_buffer, *scratch;
@@ -67,46 +68,25 @@ xccl_status_t xccl_ucx_reduce_knomial_progress(xccl_ucx_collreq_t *req)
         dist *= radix;
     poll:
         if (req->reduce_kn.active_reqs) {
-            int n_completed;
-            int n_polls = 0;
-            int max_polls =  TEAM_UCX_CTX(team)->num_to_probe;
-            while (n_polls++ < max_polls) {
-                n_completed = 0;
-                xccl_ucx_progress(team);
-                for (i=0; i<req->reduce_kn.active_reqs; i++) {
-                    if (REQ_PROCESSED == reqs[i]) {
-                        n_completed++;
-                        continue;
-                    }
-                    if (NULL == reqs[i] || reqs[i]->status == XCCL_UCX_REQUEST_DONE) {
-                        if (req->reduce_kn.phase == 1) {
-                            xccl_mem_component_reduce((void*)((ptrdiff_t)scratch + i*data_size),
-                                                      src_buffer, dst_buffer,
-                                                      req->args.reduce_info.count,
-                                                      req->args.reduce_info.dt,
-                                                      req->args.reduce_info.op,
-                                                      req->mem_type);
-                            req->reduce_kn.data_buf = dst_buffer;
-                            src_buffer = dst_buffer;
-                        }
-                        n_completed++;
-                        if (reqs[i]) {
-                            xccl_ucx_req_free(reqs[i]);
-                        }
-                        reqs[i] = REQ_PROCESSED;
-                    }
-                }
-                if (n_completed == req->reduce_kn.active_reqs) {
-                    req->reduce_kn.active_reqs = 0;
-                    req->reduce_kn.phase       = 0;
-                    memset(reqs, 0, req->reduce_kn.active_reqs*sizeof(*reqs));
-                    break;
-                }
-            }
-            if (req->reduce_kn.active_reqs) {
+            if (XCCL_INPROGRESS == xccl_ucx_testall((xccl_ucx_team_t *)team,
+                                                    reqs, req->reduce_kn.active_reqs)) {
                 req->reduce_kn.dist = dist;
                 return XCCL_OK;
             }
+            if (req->reduce_kn.phase == 1) {
+                xccl_mem_component_reduce_multi(src_buffer, scratch, dst_buffer,
+                                                req->reduce_kn.active_reqs,
+                                                req->args.reduce_info.count,
+                                                data_size,
+                                                req->args.reduce_info.dt,
+                                                req->args.reduce_info.op,
+                                                req->mem_type);
+                req->reduce_kn.data_buf = dst_buffer;
+                src_buffer = dst_buffer;
+            }
+            req->reduce_kn.active_reqs = 0;
+            req->reduce_kn.phase       = 0;
+            memset(reqs, 0, req->reduce_kn.active_reqs*sizeof(*reqs));
         }
     }
     xccl_mem_component_free(req->reduce_kn.scratch, req->mem_type);

--- a/src/team_lib/ucx/xccl_ucx_context.c
+++ b/src/team_lib/ucx/xccl_ucx_context.c
@@ -72,8 +72,12 @@ xccl_status_t xccl_ucx_create_context(xccl_team_lib_t *lib,
     } else {
         ctx->ucp_eps = NULL;
     }
-    ctx->num_to_probe = 10;
-    ctx->next_cid     = 0;
+    ctx->num_to_probe       = cfg->num_to_probe;
+    ctx->barrier_kn_radix   = cfg->barrier_kn_radix;
+    ctx->bcast_kn_radix     = cfg->bcast_kn_radix;
+    ctx->reduce_kn_radix    = cfg->reduce_kn_radix;
+    ctx->allreduce_kn_radix = cfg->allreduce_kn_radix;
+    ctx->next_cid           = 0;
     *context = &ctx->super;
     return XCCL_OK;
 }

--- a/src/team_lib/ucx/xccl_ucx_context.h
+++ b/src/team_lib/ucx/xccl_ucx_context.h
@@ -14,8 +14,12 @@ typedef struct xccl_team_lib_ucx_context {
     ucp_context_h         ucp_context;
     ucp_worker_h          ucp_worker;
     size_t                ucp_addrlen;
-    int                   num_to_probe;
     int                   next_cid;
+    unsigned              num_to_probe;
+    unsigned              barrier_kn_radix;
+    unsigned              bcast_kn_radix;
+    unsigned              allreduce_kn_radix;
+    unsigned              reduce_kn_radix;
 } xccl_team_lib_ucx_context_t;
 
 xccl_status_t xccl_ucx_create_context(xccl_team_lib_t *lib,
@@ -24,4 +28,7 @@ xccl_status_t xccl_ucx_create_context(xccl_team_lib_t *lib,
                                       xccl_tl_context_t **context);
 xccl_status_t xccl_ucx_destroy_context(xccl_tl_context_t *context);
 
+#define TEAM_UCX_CTX(_team) (ucs_derived_of((_team)->super.ctx, xccl_team_lib_ucx_context_t))
+#define TEAM_UCX_CTX_REQ(_req) (ucs_derived_of((_req)->team->ctx, xccl_team_lib_ucx_context_t))
+#define TEAM_UCX_WORKER(_team) TEAM_UCX_CTX(_team)->ucp_worker
 #endif

--- a/src/team_lib/ucx/xccl_ucx_lib.c
+++ b/src/team_lib/ucx/xccl_ucx_lib.c
@@ -41,6 +41,36 @@ static ucs_config_field_t xccl_tl_ucx_context_config_table[] = {
      ucs_offsetof(xccl_tl_ucx_context_config_t, devices), UCS_CONFIG_TYPE_STRING_ARRAY
     },
 
+    {"BARRIER_KN_RADIX", "4",
+     "Radix value for knomial barrier algorithm",
+     ucs_offsetof(xccl_tl_ucx_context_config_t, barrier_kn_radix),
+     UCS_CONFIG_TYPE_UINT
+    },
+
+    {"BCAST_KN_RADIX", "4",
+     "Radix value for knomial bcast algorithm",
+     ucs_offsetof(xccl_tl_ucx_context_config_t, bcast_kn_radix),
+     UCS_CONFIG_TYPE_UINT
+    },
+
+    {"REDUCE_KN_RADIX", "4",
+     "Radix value for knomial reduce algorithm",
+     ucs_offsetof(xccl_tl_ucx_context_config_t, reduce_kn_radix),
+     UCS_CONFIG_TYPE_UINT
+    },
+
+    {"ALLREDUCE_KN_RADIX", "4",
+     "Radix value for knomial allreduce algorithm",
+     ucs_offsetof(xccl_tl_ucx_context_config_t, allreduce_kn_radix),
+     UCS_CONFIG_TYPE_UINT
+    },
+
+    {"NUM_TO_PROBE", "10",
+     "Number of p2p request tests in a single poll loop",
+     ucs_offsetof(xccl_tl_ucx_context_config_t, num_to_probe),
+     UCS_CONFIG_TYPE_UINT
+    },
+
     {NULL}
 };
 

--- a/src/team_lib/ucx/xccl_ucx_lib.h
+++ b/src/team_lib/ucx/xccl_ucx_lib.h
@@ -20,6 +20,11 @@ typedef struct xccl_team_lib_ucx_config {
 typedef struct xccl_tl_ucx_context_config {
     xccl_tl_context_config_t super;
     ucs_config_names_array_t devices;
+    unsigned                 barrier_kn_radix;
+    unsigned                 bcast_kn_radix;
+    unsigned                 reduce_kn_radix;
+    unsigned                 allreduce_kn_radix;
+    unsigned                 num_to_probe;
 } xccl_tl_ucx_context_config_t;
 
 extern xccl_team_lib_ucx_t xccl_team_lib_ucx;

--- a/src/team_lib/ucx/xccl_ucx_sendrecv.h
+++ b/src/team_lib/ucx/xccl_ucx_sendrecv.h
@@ -14,9 +14,6 @@ void xccl_ucx_send_completion_cb(void* request, ucs_status_t status);
 void xccl_ucx_recv_completion_cb(void* request, ucs_status_t status,
                                      ucp_tag_recv_info_t *info);
 
-#define TEAM_UCX_CTX(_team) (ucs_derived_of((_team)->super.ctx, xccl_team_lib_ucx_context_t))
-#define TEAM_UCX_WORKER(_team) TEAM_UCX_CTX(_team)->ucp_worker
-
 #define TEAM_UCX_MAKE_TAG(_tag, _rank, _context_id)                 \
     ((((uint64_t) (_tag))        << TEAM_UCX_TAG_BITS_OFFSET)  |    \
      (((uint64_t) (_rank))       << TEAM_UCX_RANK_BITS_OFFSET) |    \


### PR DESCRIPTION
Switching to reduce_multi api in the team/ucx knomial reduce. Former poll/reduce approach does not give any advantage/overlap even with high radixes (tested on osu_reduce) but complicates the code. This also improves cuda case.