### PR TITLE
xccl.h: context query

### DIFF
--- a/src/api/xccl.h
+++ b/src/api/xccl.h
@@ -80,7 +80,7 @@ typedef struct xccl_lib_params {
     unsigned reproducible;
     unsigned thread_mode;
     uint64_t team_usage;
-    size_t   coll_types;
+    uint64_t coll_types;
 } xccl_lib_params_t;
 
 /**
@@ -177,7 +177,7 @@ xccl_status_t xccl_get_tl_list(xccl_lib_h lib, xccl_tl_id_t **tls,
 void xccl_free_tl_list(xccl_tl_id_t *tls);
 
 enum xccl_tl_attr_field {
-    XCCL_TL_ATRR_FIELD_CONTEXT_CREATE_MODE = UCS_BIT(0),
+    XCCL_TL_ATTR_FIELD_CONTEXT_CREATE_MODE = UCS_BIT(0),
     XCCL_TL_ATTR_FIELD_DEVICES_COUNT       = UCS_BIT(1),
     XCCL_TL_ATTR_FILED_DEVICES             = UCS_BIT(2)
 };
@@ -196,8 +196,19 @@ typedef struct xccl_tl_attr {
 
 xccl_status_t xccl_tl_query(xccl_lib_h lib, xccl_tl_id_t *tl,
                             xccl_tl_attr_t *tl_attr);
-
 void xccl_free_tl_attr(xccl_tl_attr_t *attr);
+
+enum xccl_ctx_attr_field {
+    XCCL_CTX_ATTR_FIELD_SUPPORTED_COLLS = UCS_BIT(0),
+};
+
+typedef struct xccl_ctx_attr {
+    uint64_t  field_mask;
+    uint64_t  supported_colls;
+} xccl_ctx_attr_t;
+
+xccl_status_t xccl_ctx_query(xccl_context_h ctx, xccl_ctx_attr_t *attr);
+void xccl_free_ctx_attr(xccl_ctx_attr_t *attr);
 
 enum xccl_context_params_field {
     XCCL_CONTEXT_PARAM_FIELD_THREAD_MODE          = UCS_BIT(0),

--- a/src/core/xccl_query.c
+++ b/src/core/xccl_query.c
@@ -6,6 +6,7 @@
 
 #include <xccl_lib.h>
 #include <xccl_team_lib.h>
+#include <xccl_context.h>
 #include <stdlib.h>
 
 xccl_status_t xccl_get_tl_list(xccl_lib_h lib, xccl_tl_id_t **tls,
@@ -60,4 +61,20 @@ void xccl_free_tl_attr(xccl_tl_attr_t *attr) {
     if (attr->field_mask & XCCL_TL_ATTR_FILED_DEVICES) {
         free(attr->devices);
     }
+}
+
+xccl_status_t xccl_ctx_query(xccl_context_h ctx, xccl_ctx_attr_t *attr)
+{
+    int i;
+    if (attr->field_mask & XCCL_CTX_ATTR_FIELD_SUPPORTED_COLLS) {
+        attr->supported_colls = 0;
+        for (i = 0; i < ctx->n_tl_ctx; i++) {
+            attr->supported_colls |= ctx->tl_ctx[i]->lib->params.coll_types;
+        }
+    }
+    return XCCL_OK;
+}
+
+void xccl_free_ctx_attr(xccl_ctx_attr_t *attr)
+{
 }

--- a/src/team_lib/ucx/xccl_ucx_lib.c
+++ b/src/team_lib/ucx/xccl_ucx_lib.c
@@ -289,7 +289,7 @@ static xccl_status_t xccl_ucx_lib_query(xccl_team_lib_h lib, xccl_tl_attr_t *tl_
     char   (*devices)[16];
     int    i, rc, p;
 
-    if (tl_attr->field_mask & XCCL_TL_ATRR_FIELD_CONTEXT_CREATE_MODE) {
+    if (tl_attr->field_mask & XCCL_TL_ATTR_FIELD_CONTEXT_CREATE_MODE) {
         tl_attr->context_create_mode = XCCL_TEAM_LIB_CONTEXT_CREATE_MODE_LOCAL;
     }
 


### PR DESCRIPTION
When context is created user may want to query which collectives
are supported by it. It is the property of ctx not lib since ctx
may contain not all the TLS that are in lib.

The api is used in ompi/coll/xccl to check which collectives the coll/xccl module should report as supported.