### PR TITLE
fixes to build with ucx + cuda

### DIFF
--- a/cudalt.py
+++ b/cudalt.py
@@ -57,7 +57,8 @@ if rv != 0:
 	sys.exit(1)
 
 # get libtool version
-fd = os.popen("libtool --version")
+libtool_path = os.path.join(os.path.dirname(__file__), "libtool")
+fd = os.popen(libtool_path + " --version")
 libtool_version = fd.readline()
 fd.close()
 

--- a/src/utils/cuda/reduce/Makefile.am
+++ b/src/utils/cuda/reduce/Makefile.am
@@ -8,7 +8,7 @@
 #
 
 NVCC = nvcc
-NVCCFLAGS = "-I${XCCL_TOP_SRCDIR}/src -I${XCCL_TOP_SRCDIR}/src/core" --compiler-options -fno-rtti,-fno-exceptions
+NVCCFLAGS = "-I${XCCL_TOP_SRCDIR}/src -I${XCCL_TOP_SRCDIR}/src/core" --compiler-options -fno-rtti,-fno-exceptions $(UCX_CPPFLAGS)
 NV_ARCH_FLAGS = -arch=sm_50 \
 		-gencode=arch=compute_37,code=sm_37 \
 		-gencode=arch=compute_50,code=sm_50 \


### PR DESCRIPTION
This change fixes two errors I encountered when trying to build XCCL with CUDA support. My configure line was as follows:
```
./configure --with-ucx=/public/apps/ucx/1.9/gcc.7.4.0-cuda.10.1/ \
--with-cuda=/public/apps/cuda/10.1 \
--prefix=/private/home/tbirch/.conda/envs/torch160-ucx/
```

### First error:
```
In file included from /private/home/tbirch/src/xccl/src/api/xccl.h:11:0,
                 from xccl_cuda_reduce.cu:1:
/private/home/tbirch/src/xccl/src/api/xccl_tls.h:9:10: fatal error: ucs/config/types.h: No such file or directory
```
Fixed by adding $(UCX_CPPFLAGS) to NVCCFLAGS

### Second error
`libtool:   error: 'xccl_cuda_reduce.lo' is not a valid libtool object`
Fixed by referring to included libtool in top level directory