### PR TITLE
Hier schedule fix no socket

### DIFF
--- a/src/team_lib/hier/xccl_hier_lib.c
+++ b/src/team_lib/hier/xccl_hier_lib.c
@@ -177,6 +177,7 @@ xccl_hier_barrier_init(xccl_coll_op_args_t *coll_args,
             .socket_leaders = ctx->tls[ucs_ilog2(XCCL_TL_SHMSEG)].enabled ?
                               XCCL_HIER_PAIR_SOCKET_LEADERS_SHMSEG :
                               XCCL_HIER_PAIR_SOCKET_LEADERS_UCX,
+            .node           = XCCL_HIER_PAIR_NODE_UCX,
         },
     };
     build_barrier_schedule(ucs_derived_of(team, xccl_hier_team_t),

--- a/src/team_lib/hier/xccl_hier_lib.c
+++ b/src/team_lib/hier/xccl_hier_lib.c
@@ -117,6 +117,7 @@ xccl_hier_allreduce_init(xccl_coll_op_args_t *coll_args,
             .socket_leaders = ctx->tls[ucs_ilog2(XCCL_TL_SHMSEG)].enabled ?
                               XCCL_HIER_PAIR_SOCKET_LEADERS_SHMSEG :
                               XCCL_HIER_PAIR_SOCKET_LEADERS_UCX,
+            .node           = XCCL_HIER_PAIR_NODE_UCX,
         },
     };
     build_allreduce_schedule(ucs_derived_of(team, xccl_hier_team_t), (*coll_args),
@@ -147,6 +148,7 @@ xccl_hier_bcast_init(xccl_coll_op_args_t *coll_args,
                 .socket_leaders = ctx->tls[ucs_ilog2(XCCL_TL_SHMSEG)].enabled ?
                                   XCCL_HIER_PAIR_SOCKET_LEADERS_SHMSEG :
                                   XCCL_HIER_PAIR_SOCKET_LEADERS_UCX,
+                .node           = XCCL_HIER_PAIR_NODE_UCX,
             },
         };
         build_bcast_schedule(ucs_derived_of(team, xccl_hier_team_t), (*coll_args),

--- a/src/team_lib/hier/xccl_hier_schedule.h
+++ b/src/team_lib/hier/xccl_hier_schedule.h
@@ -103,6 +103,7 @@ typedef struct xccl_hier_schedule_pairs_t {
     xccl_hier_pair_type_t  socket;
     xccl_hier_pair_type_t  socket_leaders;
     xccl_hier_pair_type_t  node_leaders;
+    xccl_hier_pair_type_t  node;
 } xccl_hier_schedule_pairs_t;
 
 typedef struct xccl_hier_bcast_spec {

--- a/src/team_lib/hier/xccl_hier_schedule_allreduce.c
+++ b/src/team_lib/hier/xccl_hier_schedule_allreduce.c
@@ -15,17 +15,30 @@
 xccl_status_t build_allreduce_schedule(xccl_hier_team_t *team, xccl_coll_op_args_t coll,
                                        xccl_hier_allreduce_spec_t spec, coll_schedule_t **sched)
 {
-    int have_node_leaders_group = (team->sbgps[SBGP_NODE_LEADERS].status == SBGP_ENABLED);
-    int have_socket_group = (team->sbgps[SBGP_SOCKET].status == SBGP_ENABLED);
+    int have_node_leaders_group   = (team->sbgps[SBGP_NODE_LEADERS].status == SBGP_ENABLED);
+    int have_socket_group         = (team->sbgps[SBGP_SOCKET].status == SBGP_ENABLED);
     int have_socket_leaders_group = (team->sbgps[SBGP_SOCKET_LEADERS].status == SBGP_ENABLED);
+    int have_node_group           = (team->sbgps[SBGP_NODE].status == SBGP_ENABLED);
 
-    int node_leaders_group_exists = (team->sbgps[SBGP_NODE_LEADERS].status != SBGP_NOT_EXISTS);
-    int socket_group_exists = (team->sbgps[SBGP_SOCKET].status != SBGP_NOT_EXISTS);
+    int node_leaders_group_exists   = (team->sbgps[SBGP_NODE_LEADERS].status != SBGP_NOT_EXISTS);
+    int socket_group_exists         = (team->sbgps[SBGP_SOCKET].status != SBGP_NOT_EXISTS);
     int socket_leaders_group_exists = (team->sbgps[SBGP_SOCKET_LEADERS].status != SBGP_NOT_EXISTS);
-    sbgp_type_t top_sbgp = node_leaders_group_exists ? SBGP_NODE_LEADERS :
-        (socket_leaders_group_exists ? SBGP_SOCKET_LEADERS : SBGP_SOCKET);
+    int node_group_exists           = (team->sbgps[SBGP_NODE].status != SBGP_NOT_EXISTS);
 
+    sbgp_type_t top_sbgp;
     coll_schedule_sequential_t *schedule = (coll_schedule_sequential_t *)malloc(sizeof(*schedule));
+
+    if (node_leaders_group_exists) {
+        top_sbgp = SBGP_NODE_LEADERS;
+    } else if (socket_leaders_group_exists) {
+        top_sbgp = SBGP_SOCKET_LEADERS;
+    } else if (socket_group_exists) {
+        top_sbgp = SBGP_SOCKET;
+    } else {
+        assert(node_group_exists);
+        top_sbgp = SBGP_NODE;
+    }
+
     schedule->super.super.hier_team = team;
     schedule->super.super.type = XCCL_COLL_SCHED_SEQ;
     schedule->super.super.progress = coll_schedule_progress_sequential;
@@ -61,6 +74,21 @@ xccl_status_t build_allreduce_schedule(xccl_hier_team_t *team, xccl_coll_op_args
         coll.buffer_info.src_buffer = coll.buffer_info.dst_buffer;
     }
 
+    if (team->no_socket && have_node_group) {
+        assert(c == 0);
+        /* !hava_socket_group && ! have_socket_leaders_group */
+        if (top_sbgp == SBGP_NODE) {
+            coll.coll_type = XCCL_ALLREDUCE;
+            schedule->super.args[c].xccl_coll = coll;
+        } else {
+            coll.coll_type = XCCL_REDUCE;
+            schedule->super.args[c].xccl_coll = coll;
+        }
+        schedule->super.args[c].pair = team->pairs[spec.pairs.node];
+        c++;
+        coll.buffer_info.src_buffer = coll.buffer_info.dst_buffer;
+    }
+
     if (have_node_leaders_group) {
         assert(top_sbgp == SBGP_NODE_LEADERS);
         coll.coll_type = XCCL_ALLREDUCE;
@@ -82,6 +110,14 @@ xccl_status_t build_allreduce_schedule(xccl_hier_team_t *team, xccl_coll_op_args
         schedule->super.args[c].pair = team->pairs[spec.pairs.socket];
         c++;
     }
+
+    if (team->no_socket && have_node_group  && top_sbgp != SBGP_NODE) {
+        coll.coll_type = XCCL_BCAST;
+        schedule->super.args[c].xccl_coll = coll;
+        schedule->super.args[c].pair = team->pairs[spec.pairs.node];
+        c++;
+    }
+
     schedule->super.n_colls = c;
     schedule->super.n_completed_colls = 0;
     schedule->req = NULL;

--- a/src/team_lib/hier/xccl_hier_schedule_barrier.c
+++ b/src/team_lib/hier/xccl_hier_schedule_barrier.c
@@ -18,15 +18,26 @@ xccl_status_t build_barrier_schedule(xccl_hier_team_t *team,
     int have_node_leaders_group     = (team->sbgps[SBGP_NODE_LEADERS].status == SBGP_ENABLED);
     int have_socket_group           = (team->sbgps[SBGP_SOCKET].status == SBGP_ENABLED);
     int have_socket_leaders_group   = (team->sbgps[SBGP_SOCKET_LEADERS].status == SBGP_ENABLED);
+    int have_node_group             = (team->sbgps[SBGP_NODE].status == SBGP_ENABLED);
 
     int node_leaders_group_exists   = (team->sbgps[SBGP_NODE_LEADERS].status != SBGP_NOT_EXISTS);
     int socket_group_exists         = (team->sbgps[SBGP_SOCKET].status != SBGP_NOT_EXISTS);
     int socket_leaders_group_exists = (team->sbgps[SBGP_SOCKET_LEADERS].status != SBGP_NOT_EXISTS);
+    int node_group_exists           = (team->sbgps[SBGP_NODE].status != SBGP_NOT_EXISTS);
 
-    sbgp_type_t top_sbgp = node_leaders_group_exists ? SBGP_NODE_LEADERS :
-        (socket_leaders_group_exists ? SBGP_SOCKET_LEADERS : SBGP_SOCKET);
-
+    sbgp_type_t top_sbgp;
     coll_schedule_sequential_t *schedule = (coll_schedule_sequential_t *)malloc(sizeof(*schedule));
+
+    if (node_leaders_group_exists) {
+        top_sbgp = SBGP_NODE_LEADERS;
+    } else if (socket_leaders_group_exists) {
+        top_sbgp = SBGP_SOCKET_LEADERS;
+    } else if (socket_group_exists) {
+        top_sbgp = SBGP_SOCKET;
+    } else {
+        assert(node_group_exists);
+        top_sbgp = SBGP_NODE;
+    }
     schedule->super.super.hier_team = team;
     schedule->super.super.type = XCCL_COLL_SCHED_SEQ;
     schedule->super.super.progress = coll_schedule_progress_sequential;
@@ -63,6 +74,20 @@ xccl_status_t build_barrier_schedule(xccl_hier_team_t *team,
         c++;
     }
 
+    if (team->no_socket && have_node_group) {
+        assert(c == 0);
+        /* !hava_socket_group && ! have_socket_leaders_group */
+        if (top_sbgp == SBGP_NODE) {
+            coll.coll_type = XCCL_BARRIER;
+            schedule->super.args[c].xccl_coll = coll;
+        } else {
+            coll.coll_type = XCCL_FANIN;
+            schedule->super.args[c].xccl_coll = coll;
+        }
+        schedule->super.args[c].pair = team->pairs[spec.pairs.node];
+        c++;
+    }
+
     if (have_node_leaders_group) {
         assert(top_sbgp == SBGP_NODE_LEADERS);
         coll.coll_type = XCCL_BARRIER;
@@ -84,6 +109,14 @@ xccl_status_t build_barrier_schedule(xccl_hier_team_t *team,
         schedule->super.args[c].pair = team->pairs[spec.pairs.socket];
         c++;
     }
+
+    if (team->no_socket && have_node_group  && top_sbgp != SBGP_NODE) {
+        coll.coll_type = XCCL_FANOUT;
+        schedule->super.args[c].xccl_coll = coll;
+        schedule->super.args[c].pair = team->pairs[spec.pairs.node];
+        c++;
+    }
+
     schedule->super.n_colls = c;
     schedule->super.n_completed_colls = 0;
     schedule->req = NULL;

--- a/src/team_lib/hier/xccl_hier_team.c
+++ b/src/team_lib/hier/xccl_hier_team.c
@@ -89,23 +89,33 @@ xccl_status_t xccl_hier_team_create_post(xccl_tl_context_t *context,
     XCCL_TEAM_SUPER_INIT(hier_team->super, context, params);
 
     for (i=0; i<SBGP_LAST; i++) {
-        hier_team->sbgps[i].status = SBGP_DISABLED;
+        hier_team->sbgps[i].status = SBGP_NOT_EXISTS;
     }
-
+    hier_team->no_socket = 0;
+    for (i=0; i<size; i++) {
+        if (ctx->procs[xccl_hier_team_rank2ctx(hier_team, i)].socketid < 0) {
+            hier_team->no_socket = 1;
+            break;
+        }
+    }
     /* SBGP_NODE has to be always created first, it is used to
        create other sbgps: socket and socket_leaders */
     sbgp_create(hier_team, SBGP_NODE);
-    sbgp_create(hier_team, SBGP_SOCKET);
     sbgp_create(hier_team, SBGP_NODE_LEADERS);
-    sbgp_create(hier_team, SBGP_SOCKET_LEADERS);
-
-    xccl_hier_create_pair(&hier_team->sbgps[SBGP_SOCKET], hier_team,
-                          XCCL_TL_UCX, XCCL_HIER_PAIR_SOCKET_UCX);
-    xccl_hier_create_pair(&hier_team->sbgps[SBGP_SOCKET_LEADERS], hier_team,
-                          XCCL_TL_UCX, XCCL_HIER_PAIR_SOCKET_LEADERS_UCX);
+    if (!hier_team->no_socket) {
+        sbgp_create(hier_team, SBGP_SOCKET);
+        sbgp_create(hier_team, SBGP_SOCKET_LEADERS);
+        xccl_hier_create_pair(&hier_team->sbgps[SBGP_SOCKET], hier_team,
+                              XCCL_TL_UCX, XCCL_HIER_PAIR_SOCKET_UCX);
+        xccl_hier_create_pair(&hier_team->sbgps[SBGP_SOCKET_LEADERS], hier_team,
+                              XCCL_TL_UCX, XCCL_HIER_PAIR_SOCKET_LEADERS_UCX);
+    } else {
+        xccl_hier_create_pair(&hier_team->sbgps[SBGP_NODE], hier_team,
+                              XCCL_TL_UCX, XCCL_HIER_PAIR_NODE_UCX);
+    }
     xccl_hier_create_pair(&hier_team->sbgps[SBGP_NODE_LEADERS], hier_team,
                           XCCL_TL_UCX, XCCL_HIER_PAIR_NODE_LEADERS_UCX);
-    
+
     if (ctx->tls[ucs_ilog2(XCCL_TL_SHMSEG)].enabled) {
         xccl_hier_create_pair(&hier_team->sbgps[SBGP_SOCKET], hier_team,
                               XCCL_TL_SHMSEG, XCCL_HIER_PAIR_SOCKET_SHMSEG);

--- a/src/team_lib/hier/xccl_hier_team.h
+++ b/src/team_lib/hier/xccl_hier_team.h
@@ -27,10 +27,11 @@ typedef enum {
 } xccl_hier_pair_type_t;
 
 typedef struct xccl_hier_team {
-    xccl_tl_team_t             super;
-    sbgp_t                     sbgps[SBGP_LAST];
-    xccl_hier_pair_t           *pairs[XCCL_HIER_PAIR_LAST];
-    int                        node_leader_rank;
+    xccl_tl_team_t   super;
+    sbgp_t           sbgps[SBGP_LAST];
+    xccl_hier_pair_t *pairs[XCCL_HIER_PAIR_LAST];
+    int              node_leader_rank;
+    int              no_socket;
 } xccl_hier_team_t;
 
 xccl_status_t xccl_hier_team_create_post(xccl_tl_context_t *context,


### PR DESCRIPTION
If processes are not bound to a socket then socket and socket_leaders subgroups are not available. Need to build schedules using node_group in this case.