### PR TITLE
team_lib/mhba: adds ucx team creation and barrier

### DIFF
--- a/src/core/xccl_context.c
+++ b/src/core/xccl_context.c
@@ -70,6 +70,7 @@ xccl_status_t xccl_context_create(xccl_lib_h lib,
             if (tlib->team_context_create(tlib, &ctx->params, config->configs[tl_index], &tl_ctx) == XCCL_OK) {
                 ctx->tl_ctx[ctx->n_tl_ctx++] = tl_ctx;
                 tl_ctx->ctx = ctx;
+                tl_ctx->tl_id = i;
                 status = xccl_ctx_progress_queue_init(&tl_ctx->pq,params->thread_mode);
                 if(status != XCCL_OK){
                     return status;
@@ -84,6 +85,19 @@ xccl_status_t xccl_context_create(xccl_lib_h lib,
 
     *context = ctx;
     return XCCL_OK;
+}
+
+xccl_tl_context_t* xccl_get_tl_context(xccl_context_t *ctx, xccl_tl_id_t tl_id)
+{
+    int i;
+    xccl_tl_context_t *tl_ctx;
+    for (i = 0; i < ctx->n_tl_ctx; i++) {
+        tl_ctx = ctx->tl_ctx[i];
+        if (tl_ctx->tl_id == tl_id) {
+            return tl_ctx;
+        }
+    }
+    return NULL;
 }
 
 xccl_status_t xccl_context_progress(xccl_context_h context)

--- a/src/core/xccl_context.h
+++ b/src/core/xccl_context.h
@@ -25,4 +25,5 @@ typedef struct xccl_context_config {
     int                      n_tl_cfg;
 }xccl_context_config_t;
 
+xccl_tl_context_t* xccl_get_tl_context(xccl_context_t *ctx, xccl_tl_id_t tl_id);
 #endif

--- a/src/core/xccl_team_lib.h
+++ b/src/core/xccl_team_lib.h
@@ -83,6 +83,7 @@ typedef struct xccl_team_lib {
 
 typedef struct xccl_progress_queue xccl_progress_queue_t;
 typedef struct xccl_tl_context {
+    xccl_tl_id_t           tl_id;
     xccl_team_lib_t       *lib;
     xccl_context_t        *ctx;
     xccl_context_params_t params;

--- a/src/team_lib/mhba/xccl_mhba_collective.h
+++ b/src/team_lib/mhba/xccl_mhba_collective.h
@@ -22,6 +22,7 @@ typedef struct xccl_mhba_coll_req {
     xccl_mhba_team_t              *team;
     int                           asr_rank;
     int                           seq_num;
+    xccl_tl_coll_req_t            *barrier_req;
 } xccl_mhba_coll_req_t;
 
 xccl_status_t

--- a/src/team_lib/mhba/xccl_mhba_lib.h
+++ b/src/team_lib/mhba/xccl_mhba_lib.h
@@ -76,6 +76,7 @@ typedef struct xccl_mhba_net {
         void *addr;
         uint32_t rkey;
     } *remote_ctrl;
+    xccl_tl_team_t *ucx_team;
 } xccl_mhba_net_t;
 
 typedef struct xccl_mhba_team {


### PR DESCRIPTION
UCX team is created for ASR net subgroup and used to run barrier in the a2a alg.