### PR TITLE
TEAM/MHBA: Adds mkey cache

### DIFF
--- a/src/team_lib/mhba/xccl_mhba_lib.c
+++ b/src/team_lib/mhba/xccl_mhba_lib.c
@@ -55,6 +55,7 @@ static xccl_status_t xccl_mhba_lib_open(xccl_team_lib_h         self,
     xccl_team_lib_mhba_config_t *cfg =
         ucs_derived_of(config, xccl_team_lib_mhba_config_t);
 
+    UCS_STATIC_ASSERT(sizeof(xccl_mhba_ctrl_t) <= MHBA_CTRL_SIZE);
     tl->config.super.log_component.log_level =
         cfg->super.log_component.log_level;
     sprintf(tl->config.super.log_component.name, "%s", "TEAM_MHBA");
@@ -191,6 +192,9 @@ static xccl_status_t xccl_mhba_collective_finalize(xccl_tl_coll_req_t *request)
     xccl_status_t         status = XCCL_OK;
     xccl_mhba_coll_req_t *req  = ucs_derived_of(request, xccl_mhba_coll_req_t);
     xccl_mhba_team_t     * team = req->team;
+    team->previous_msg_size[SEQ_INDEX(req->seq_num)] = req->args.buffer_info.len;
+    team->previous_send_address[SEQ_INDEX(req->seq_num)] = req->send_rcache_region_p->mr->addr;
+    team->previous_recv_address[SEQ_INDEX(req->seq_num)] = req->recv_rcache_region_p->mr->addr;
     ucs_rcache_region_put(team->rcache,req->send_rcache_region_p->region);
     ucs_rcache_region_put(team->rcache,req->recv_rcache_region_p->region);
     if (team->transpose) {

--- a/src/team_lib/mhba/xccl_mhba_mkeys.c
+++ b/src/team_lib/mhba/xccl_mhba_mkeys.c
@@ -282,20 +282,23 @@ xccl_status_t xccl_mhba_populate_send_recv_mkeys(xccl_mhba_team_t     *team,
     int               recv_mem_access_flags =
         IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE;
     xccl_status_t     status;
-    status = populate_mkey(
-        node, send_mem_access_flags, node->ops[index].send_mkey,
-        node->ops[index].send_umr_data, req->block_size, team->size, 1);
-    if (status != XCCL_OK) {
-        xccl_mhba_error("Failed to populate send umr[%d]", index);
-        return status;
+    if(xccl_mhba_get_my_ctrl(team, index)->mkey_cache_flag & XCCL_MHBA_NEED_SEND_MKEY_UPDATE) {
+        status = populate_mkey(
+                node, send_mem_access_flags, node->ops[index].send_mkey,
+                node->ops[index].send_umr_data, req->block_size, team->size, 1);
+        if (status != XCCL_OK) {
+            xccl_mhba_error("Failed to populate send umr[%d]", index);
+            return status;
+        }
     }
-
-    status = populate_mkey(
-        node, recv_mem_access_flags, node->ops[index].recv_mkey,
-        node->ops[index].recv_umr_data, req->block_size, team->size, 1);
-    if (status != XCCL_OK) {
-        xccl_mhba_error("Failed to populate recv umr[%d]", index);
-        return status;
+    if(xccl_mhba_get_my_ctrl(team, index)->mkey_cache_flag & XCCL_MHBA_NEED_RECV_MKEY_UPDATE) {
+        status = populate_mkey(
+                node, recv_mem_access_flags, node->ops[index].recv_mkey,
+                node->ops[index].recv_umr_data, req->block_size, team->size, 1);
+        if (status != XCCL_OK) {
+            xccl_mhba_error("Failed to populate recv umr[%d]", index);
+            return status;
+        }
     }
     return XCCL_OK;
 }


### PR DESCRIPTION
    ASR may skip mkey update step (for SEND or RECV) if the following
    condition is met:
	1. registration has not changed
	2. Buffer pointer has not changed
	3. Msg size has not changed

Alternative to #104 