### PR TITLE
xccl/core: Bug fix in the OOB allgather code

### DIFF
--- a/src/core/xccl_team_lib.h
+++ b/src/core/xccl_team_lib.h
@@ -103,7 +103,7 @@ xccl_oob_allgather_nb(void *sbuf, void* rbuf, size_t len,
     xccl_ep_range_t r = {
         .type = XCCL_EP_RANGE_UNDEFINED,
     };
-    oob->allgather(sbuf, rbuf, len, 0, r, oob->coll_context, req);
+    oob->allgather(sbuf, rbuf, len, oob->rank, r, oob->coll_context, req);
 }
 
 static inline void


### PR DESCRIPTION
The OOB allgather code expects each caller process to pass in its
rank, based on the API.  But the current implementation simply passes
"0" for all processes.  This worked fine so far because none of the
application codes used that value, but it could break a future code
that relies on that parameter.

Signed-off-by: Pavan Balaji <pavanbalaji.work@gmail.com>