### PR TITLE
xccl/ucx: fix allgather for IN_PLACE buffers

### DIFF
--- a/src/team_lib/ucx/allgather/allgather_ring.c
+++ b/src/team_lib/ucx/allgather/allgather_ring.c
@@ -64,7 +64,7 @@ xccl_status_t xccl_ucx_allgather_ring_start(xccl_ucx_collreq_t *req)
     ptrdiff_t sbuf       = (ptrdiff_t)req->args.buffer_info.src_buffer;
     ptrdiff_t rbuf       = (ptrdiff_t)req->args.buffer_info.dst_buffer;
 
-    if (sbuf != rbuf) {
+    if (sbuf != rbuf || group_rank) {
         xccl_ucx_send_recv((void*)(sbuf), data_size,
                            req->src_mem_type,
                            group_rank, req->tag,


### PR DESCRIPTION
The IN_PLACE code for allgather was not moving data on non-zero ranks
from the source location to the appropriate destination location.

Signed-off-by: Pavan Balaji <pavanbalaji.work@gmail.com>