### PR TITLE
xccl/mc: Added a new memcpy_async operation

### DIFF
--- a/src/utils/cuda/cuda_mem_component.c
+++ b/src/utils/cuda/cuda_mem_component.c
@@ -162,6 +162,11 @@ xccl_cuda_start_acitivity(xccl_stream_t *stream,
     return XCCL_OK;
 }
 
+xccl_status_t xccl_cuda_memcpy_async(void *sbuf, void *dbuf, size_t size, xccl_stream_t *stream)
+{
+    CUDACHECK(cudaMemcpyAsync(dbuf, sbuf, size, cudaMemcpyDefault, *((cudaStream_t *) stream->stream)));
+}
+
 xccl_status_t
 xccl_cuda_finish_acitivity(xccl_mem_component_stream_request_t *req)
 {
@@ -266,6 +271,7 @@ xccl_cuda_mem_component_t xccl_cuda_mem_component = {
     xccl_cuda_mem_type,
     xccl_cuda_reduce,
     xccl_cuda_reduce_multi,
+    xccl_cuda_memcpy_async,
     xccl_cuda_event_record,
     xccl_cuda_event_query,
     xccl_cuda_event_free,

--- a/src/utils/mem_component.c
+++ b/src/utils/mem_component.c
@@ -177,6 +177,24 @@ static const ucs_memory_type_t stream_to_mem_type[] = {
     [XCCL_STREAM_TYPE_CUDA] = UCS_MEMORY_TYPE_CUDA
 };
 
+xccl_status_t
+xccl_mem_component_memcpy_async(void *sbuf, void *dbuf, size_t size, xccl_stream_t *stream)
+{
+    int mt = stream_to_mem_type[stream->type];
+    xccl_status_t st;
+
+    if (size == 0) {
+        return XCCL_OK;
+    }
+
+    assert(mt != UCS_MEMORY_TYPE_HOST);
+    if (mem_components[mt] == NULL) {
+        xccl_error("mem component %s is not available", ucs_memory_type_names[mt]);
+    }
+
+    return mem_components[mt]->memcpy_async(sbuf, dbuf, size, stream);
+}
+
 xccl_status_t xccl_mem_component_start_acitivity(xccl_stream_t *stream,
                                                  xccl_mem_component_stream_request_t **req)
 {

--- a/src/utils/mem_component.h
+++ b/src/utils/mem_component.h
@@ -35,6 +35,7 @@ typedef struct xccl_mem_component {
     xccl_status_t (*reduce_multi)(void *sbuf1, void *sbuf2, void *rbuf,
                                   size_t count, size_t size, size_t stride,
                                   xccl_dt_t dtype, xccl_op_t op);
+    xccl_status_t (*memcpy_async)(void *sbuf, void *dbuf, size_t size, xccl_stream_t *stream);
     xccl_status_t (*event_record)(xccl_stream_t *stream,
                                   xccl_mc_event_t **event);
     xccl_status_t (*event_query)(xccl_mc_event_t *event);
@@ -60,6 +61,9 @@ xccl_status_t xccl_mem_component_type(void *ptr, ucs_memory_type_t *mem_type);
 xccl_status_t xccl_mem_component_reduce(void *sbuf1, void *sbuf2, void *target,
                                         size_t count, xccl_dt_t dtype,
                                         xccl_op_t op, ucs_memory_type_t mem_type);
+
+xccl_status_t xccl_mem_component_memcpy_async(void *sbuf, void *dbuf, size_t size,
+                                              xccl_stream_t *stream);
 
 xccl_status_t xccl_mem_component_start_acitivity(xccl_stream_t *stream,
                                                  xccl_mem_component_stream_request_t **req);


### PR DESCRIPTION
This allows the teamlib algorithms to perfom local data movement as
needed, internally.

Signed-off-by: Pavan Balaji <pavanbalaji.work@gmail.com>